### PR TITLE
redis-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.docs/
 # C extensions
 *.so
 logs/

--- a/app/cache/cache.py
+++ b/app/cache/cache.py
@@ -72,3 +72,7 @@ async def aget_meta(key: str) -> Optional[dict[str, Any]]:
 async def aset_meta(key: str, meta: dict[str, Any], ttl: int = META_TTL) -> None:
     """Salva metadados no cache híbrido (assíncrono)"""
     await tile_cache.set_meta(key, meta, ttl)
+
+def atile_lock(key: str):
+    """Lock distribuído para geração de tile (assíncrono context manager)"""
+    return tile_cache.tile_lock(key)

--- a/app/core/otel.py
+++ b/app/core/otel.py
@@ -98,9 +98,20 @@ def create_loguru_otel_sink():
     def sink(message):
         record = message.record
         level = level_map.get(record["level"].name, logging.INFO)
+        
+        # Captura exceção se existir
+        exc_info = None
+        if record["exception"] is not None:
+            exc_info = (
+                record["exception"].type,
+                record["exception"].value,
+                record["exception"].traceback,
+            )
+        
         stdlib_logger.log(
             level,
             record["message"],
+            exc_info=exc_info,
             extra={
                 "loguru_module": record["module"],
                 "loguru_function": record["function"],
@@ -109,7 +120,6 @@ def create_loguru_otel_sink():
         )
 
     return sink
-
 
 def shutdown_otel_logging():
     """Flush e shutdown do OTLP exporter."""


### PR DESCRIPTION
# Fix: Race Condition na Geração de Tiles

## Problema

Dois problemas foram identificados no fluxo de cache de tiles:

### 1. Redis gravado antes do S3 (race condition de leitura)

No `set_png`, o metadado no Redis era salvo **antes** do upload ao S3 terminar:

```python
# ANTES (com bug)
upload_task = self._upload_to_s3(s3_key, data)   # inicia upload (não espera)
await r.hset(f"tile:{key}", mapping=meta)         # Redis já tem a referência
await upload_task                                  # S3 só termina aqui
```

**Resultado:** Uma requisição concorrente encontrava o metadado no Redis, tentava buscar do S3, mas o objeto ainda não existia:

```
NoSuchKey: The specified key does not exist.
```

**Correção:** S3 é gravado primeiro, Redis só depois:

```python
# DEPOIS (corrigido)
await self._upload_to_s3(s3_key, data)            # espera upload terminar
await r.hset(f"tile:{key}", mapping=meta)          # agora sim registra no Redis
```

### 2. Múltiplos workers gerando o mesmo tile (race condition de escrita)

Sem nenhum mecanismo de lock, quando N requisições chegavam para o mesmo tile não cacheado, **todas** iniciavam a geração em paralelo:

- N chamadas ao Earth Engine (API cara e com rate limit)
- N downloads do tile
- N uploads ao S3

Desperdício de recursos e potencial throttling no Earth Engine.

## Solução: Lock Distribuído via Redis

### Mecanismo

Adicionado `tile_lock` no `HybridTileCache` usando `SET NX EX` do Redis:

- **`NX`** (Not eXists): operação atômica — apenas um worker adquire o lock
- **`EX 60`**: TTL de 60 segundos — safety net para não travar se o worker morrer

### Fluxo

```
Request A (tile X)              Request B (tile X)
──────────────────              ──────────────────
1. get_png → cache miss         1. get_png → cache miss
2. tile_lock → ADQUIRIU         2. tile_lock → ESPERANDO (poll 0.5s)
3. chama Earth Engine              ...
4. download tile                   ...
5. upload S3                       ...
6. salva Redis                     ...
7. libera lock                  3. lock liberado → should_generate=False
8. retorna PNG                  4. get_png → cache HIT
                                5. retorna PNG (sem chamar EE)
```

### Comportamento do worker que espera

Quando o lock é liberado, o worker que esperou:

1. Tenta buscar do cache (o tile já deve estar lá)
2. Se encontrou, retorna direto — **zero custo adicional**
3. Se não encontrou (lock expirou, erro no outro worker), gera normalmente como fallback

## Arquivos Modificados

| Arquivo | Mudança |
|---|---|
| `app/cache/cache_hybrid.py` | Corrigido ordem S3→Redis no `set_png`; adicionado método `tile_lock` |
| `app/cache/cache.py` | Exposto `atile_lock` como facade assíncrona |
| `app/api/layers.py` | Integrado `tile_lock` no `_serve_tile` |

## Benefícios

- **Elimina `NoSuchKey`** causado por leitura de metadado antes do upload completar
- **Reduz chamadas ao Earth Engine** — apenas 1 worker gera cada tile
- **Funciona entre containers** — lock é distribuído via Redis
- **Tolerante a falhas** — lock expira automaticamente em 60s
