### PR TITLE
feat(tiles): mitigação de 429 do Earth Engine com rotação reativa de SA

### DIFF
--- a/app/api/imagery.py
+++ b/app/api/imagery.py
@@ -29,7 +29,8 @@ from app.core.errors import tile_error_response
 from app.middleware.rate_limiter import limit_imagery
 from app.core.gee_pool import gee_retry
 from app.utils.ee_compute import compute_value
-from app.utils.http import http_get_bytes
+from app.utils.ee_tile_fetch import fetch_tile_with_rotation
+from app.utils.http import EarthEngineRateLimitedError
 from app.visualization.vis_params_db import get_landsat_vis_params_async
 from app.visualization.vis_params_loader import get_visparams, generate_landsat_list
 
@@ -459,15 +460,41 @@ async def image_tile(
         else:
             layer_url = meta["url"]
 
-        # 4 ▸ Download do tile remoto
+        # 4 ▸ Download do tile remoto via helper com rotação reativa.
+        async def _regenerate_url() -> str:
+            loop = asyncio.get_running_loop()
+            if layer == "s2_harmonized":
+                vis = await _vis_param_for_s2(visparam)
+                return await loop.run_in_executor(
+                    ee_executor, _create_s2_image_layer_sync, imageId, vis,
+                )
+            vis = await _vis_param_for_landsat(visparam, imageId)
+            return await loop.run_in_executor(
+                ee_executor, _create_landsat_image_layer_sync, imageId, vis,
+            )
+
         try:
-            png_bytes = await http_get_bytes(layer_url.format(x=x, y=y, z=z))
+            png_bytes = await fetch_tile_with_rotation(
+                cache_key=meta_key,
+                cached_url=layer_url,
+                url_factory=_regenerate_url,
+                x=x, y=y, z=z,
+                layer="imagery",
+            )
             await set_png(tile_key, png_bytes)
             return StreamingResponse(
                 io.BytesIO(png_bytes),
                 media_type="image/png",
                 headers={"X-Cache": "MISS", "X-Image-Id": imageId},
             )
+        except EarthEngineRateLimitedError as exc:
+            logger.warning(
+                f"tile_imagery_429_persistent layer={layer} imageId={imageId} "
+                f"sa_name={exc.sa_name} action=return_503"
+            )
+            resp = tile_error_response(status_code=503, reason="ee_unavailable")
+            resp.headers["X-Image-Id"] = imageId
+            return resp
         except HTTPException as exc:
             logger.exception(f"Erro ao baixar tile da imagem {imageId}")
             resp = tile_error_response.from_exception(exc)

--- a/app/api/imagery.py
+++ b/app/api/imagery.py
@@ -440,7 +440,7 @@ async def image_tile(
 
         if expired:
             try:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 if layer == "s2_harmonized":
                     vis = await _vis_param_for_s2(visparam)
                     layer_url = await loop.run_in_executor(

--- a/app/api/layers.py
+++ b/app/api/layers.py
@@ -32,7 +32,6 @@ from app.middleware.rate_limiter import limit_sentinel, limit_landsat
 from app.services.tile import tile2goehashBBOX
 from app.utils.capabilities import get_capabilities_provider
 from app.core.gee_pool import gee_retry
-from app.utils.http import http_get_bytes as _http_get_bytes
 from app.utils.ee_tile_fetch import fetch_tile_with_rotation
 from app.utils.http import EarthEngineRateLimitedError
 from app.visualization.validation import validate_landsat_request
@@ -498,6 +497,10 @@ async def _serve_tile(layer: str,
         # 3 ▸ URL EE: meta cache + TTL
         #     Lock separado por path_cache evita thundering herd na geração de URL
         meta      = await get_meta(path_cache)
+        # Circuit breaker hoistado: precisa estar disponível tanto na geração
+        # da URL (record_success/record_failure no expired branch) quanto no
+        # download (record_failure em 429 persistente após rotação do helper).
+        breaker = get_ee_circuit_breaker()
         expired   = (
             meta is None or
             (datetime.now() - datetime.fromisoformat(meta["date"])).total_seconds()/3600
@@ -506,7 +509,6 @@ async def _serve_tile(layer: str,
         if expired:
             # Circuit breaker: fail-fast quando EE está degradado. Libera
             # threads EE para outros endpoints e evita retry storm.
-            breaker = get_ee_circuit_breaker()
             if await breaker.is_open():
                 retry_after = await breaker.seconds_until_retry()
                 logger.warning(
@@ -578,7 +580,7 @@ async def _serve_tile(layer: str,
         #     regenera URL via url_factory → tenta uma vez mais.
         async def _regenerate_url() -> str:
             geom = ee.Geometry.BBox(bbox["w"], bbox["s"], bbox["e"], bbox["n"])
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             if layer == "landsat":
                 _year = datetime.fromisoformat(dates["dtStart"]).year
                 collection = get_landsat_collection(_year)
@@ -605,7 +607,14 @@ async def _serve_tile(layer: str,
             logger.info(f"Tile cached: {file_cache}")
             return StreamingResponse(io.BytesIO(png_bytes), media_type="image/png")
         except EarthEngineRateLimitedError as exc:
-            logger.warning(f"Tile 503 ee_rate_limit (após rotação): {exc}")
+            logger.warning(
+                f"tile_429_persistent_after_rotation layer={layer} "
+                f"cache_key={path_cache} sa_name={exc.sa_name} action=return_503"
+            )
+            try:
+                await breaker.record_failure()
+            except Exception:
+                logger.exception("Falha ao registrar evento no CB")
             return tile_error_response(status_code=503, reason="ee_unavailable")
         except HTTPException as exc:
             logger.exception("Erro ao baixar tile")

--- a/app/api/layers.py
+++ b/app/api/layers.py
@@ -33,6 +33,8 @@ from app.services.tile import tile2goehashBBOX
 from app.utils.capabilities import get_capabilities_provider
 from app.core.gee_pool import gee_retry
 from app.utils.http import http_get_bytes as _http_get_bytes
+from app.utils.ee_tile_fetch import fetch_tile_with_rotation
+from app.utils.http import EarthEngineRateLimitedError
 from app.visualization.validation import validate_landsat_request
 from app.visualization.vis_params_db import get_landsat_vis_params_async
 from app.visualization.vis_params_loader import get_visparams, get_landsat_vis_params, get_landsat_collection
@@ -571,13 +573,40 @@ async def _serve_tile(layer: str,
         else:
             layer_url = meta["url"]
 
-        # 4 ▸ Faz download do tile remoto
+        # 4 ▸ Faz download do tile remoto via helper com rotação reativa.
+        #     Em 429, o helper: rotaciona SA → invalida meta cache →
+        #     regenera URL via url_factory → tenta uma vez mais.
+        async def _regenerate_url() -> str:
+            geom = ee.Geometry.BBox(bbox["w"], bbox["s"], bbox["e"], bbox["n"])
+            loop = asyncio.get_event_loop()
+            if layer == "landsat":
+                _year = datetime.fromisoformat(dates["dtStart"]).year
+                collection = get_landsat_collection(_year)
+                landsat_vis = await get_landsat_vis_params_async(visparam, collection)
+                return await loop.run_in_executor(
+                    ee_executor,
+                    _create_landsat_layer_with_params,
+                    geom, dates, landsat_vis, composite_mode or "BEST_IMAGE",
+                )
+            return await loop.run_in_executor(
+                ee_executor, builder_sync, geom, dates, vis,
+            )
+
         try:
-            png_bytes = await _http_get_bytes(layer_url.format(x=x, y=y, z=z))
+            png_bytes = await fetch_tile_with_rotation(
+                cache_key=path_cache,
+                cached_url=layer_url,
+                url_factory=_regenerate_url,
+                x=x, y=y, z=z,
+                layer=layer,
+            )
             logger.info(f"Tile downloaded: {file_cache} ({len(png_bytes)} bytes), saving to cache...")
             await set_png(file_cache, png_bytes)
             logger.info(f"Tile cached: {file_cache}")
             return StreamingResponse(io.BytesIO(png_bytes), media_type="image/png")
+        except EarthEngineRateLimitedError as exc:
+            logger.warning(f"Tile 503 ee_rate_limit (após rotação): {exc}")
+            return tile_error_response(status_code=503, reason="ee_unavailable")
         except HTTPException as exc:
             logger.exception("Erro ao baixar tile")
             return tile_error_response.from_exception(exc)

--- a/app/api/layers.py
+++ b/app/api/layers.py
@@ -525,7 +525,7 @@ async def _serve_tile(layer: str,
                 if should_generate_url:
                     geom = ee.Geometry.BBox(bbox["w"], bbox["s"], bbox["e"], bbox["n"])
                     try:
-                        loop = asyncio.get_event_loop()
+                        loop = asyncio.get_running_loop()
                         if layer == "landsat":
                             year = datetime.fromisoformat(dates["dtStart"]).year
                             collection = get_landsat_collection(year)
@@ -556,7 +556,7 @@ async def _serve_tile(layer: str,
                         # Fallback: gera a URL (caso raro de expiração durante espera)
                         geom = ee.Geometry.BBox(bbox["w"], bbox["s"], bbox["e"], bbox["n"])
                         try:
-                            loop = asyncio.get_event_loop()
+                            loop = asyncio.get_running_loop()
                             if layer == "landsat":
                                 year = datetime.fromisoformat(dates["dtStart"]).year
                                 collection = get_landsat_collection(year)

--- a/app/cache/cache.py
+++ b/app/cache/cache.py
@@ -88,6 +88,14 @@ async def aset_meta(key: str, meta: dict[str, Any], ttl: int = META_TTL) -> None
     """Salva metadados no cache híbrido (assíncrono)"""
     await tile_cache.set_meta(key, meta, ttl)
 
+async def adelete_meta(key: str) -> None:
+    """Remove metadados do cache híbrido (assíncrono).
+
+    Usado pelo helper de rotação para invalidar URLs do EE quando a SA
+    que as assinou recebeu 429.
+    """
+    await tile_cache.delete_meta(key)
+
 def atile_lock(key: str):
     """Lock distribuído para geração de tile (assíncrono context manager)"""
     return tile_cache.tile_lock(key)

--- a/app/cache/cache_hybrid.py
+++ b/app/cache/cache_hybrid.py
@@ -297,6 +297,15 @@ class HybridTileCache:
         async with self._get_redis() as r:
             await r.set(f"meta:{key}", orjson.dumps(meta), ex=ttl)
 
+    async def delete_meta(self, key: str) -> None:
+        """Remove metadados (URL EE etc.) do Redis. Usado para invalidar
+        URLs cacheadas vinculadas a SAs penalizadas por 429.
+
+        Idempotente — DEL em chave inexistente é no-op no Redis.
+        """
+        async with self._get_redis() as r:
+            await r.delete(f"meta:{key}")
+
     async def batch_get_tiles(self, keys: List[str]) -> Dict[str, Optional[bytes]]:
         """Busca múltiplos tiles em paralelo para melhor performance"""
         tasks = [self.get_png(key) for key in keys]

--- a/app/core/gee_pool.py
+++ b/app/core/gee_pool.py
@@ -277,6 +277,11 @@ class ServiceAccountPool:
                     pipe.hincrby(metrics_key, "errors_429", 1)
                     pipe.hset(metrics_key, "last_429_at", str(now))
                     pipe.execute()
+                    try:
+                        from app.core.metrics import gee_sa_http_429_total
+                        gee_sa_http_429_total.labels(sa_name=sa_name).inc()
+                    except Exception:
+                        pass
                     return
             except ValueError:
                 pass
@@ -286,6 +291,15 @@ class ServiceAccountPool:
         pipe.hset(metrics_key, "last_429_at", str(now))
         pipe.hset(metrics_key, "cooldown_until", str(new_cooldown_end))
         pipe.execute()
+
+        try:
+            from app.core.metrics import gee_sa_http_429_total, gee_sa_in_cooldown
+            gee_sa_http_429_total.labels(sa_name=sa_name).inc()
+            gee_sa_in_cooldown.labels(sa_name=sa_name).set(1)
+        except Exception:
+            # Métrica é best-effort — falha de instrumentação não pode
+            # quebrar a rotação que é caminho crítico.
+            pass
 
     # ---- Heartbeat ----
 
@@ -347,6 +361,11 @@ class ServiceAccountPool:
             in_cooldown = bool(
                 cooldown_until and cooldown_until != "" and float(cooldown_until) > now
             )
+            try:
+                from app.core.metrics import gee_sa_in_cooldown
+                gee_sa_in_cooldown.labels(sa_name=sa_name).set(1 if in_cooldown else 0)
+            except Exception:
+                pass
 
             result["accounts"][sa_name] = {
                 "active_workers": int(score),
@@ -457,6 +476,15 @@ class WorkerGEEManager:
                 f"Worker {self._worker_id} rotacionou: "
                 f"{old_sa} → {self._current_sa.name}"
             )
+            try:
+                from app.core.metrics import gee_sa_rotation_total
+                gee_sa_rotation_total.labels(
+                    from_sa=old_sa,
+                    to_sa=self._current_sa.name,
+                    trigger="http_429",
+                ).inc()
+            except Exception:
+                pass
 
     def report_http_429(self) -> None:
         """Registra um 429 de download HTTP (métrica, sem rotação de SA)."""

--- a/app/core/gee_pool.py
+++ b/app/core/gee_pool.py
@@ -474,8 +474,16 @@ class WorkerGEEManager:
             old_sa = self._current_sa.name
             logger.warning(f"Rotacionando SA {old_sa} por 429 no worker {self._worker_id}")
 
-            # Reportar 429 e liberar
-            self._pool.report_429(old_sa)
+            # Reportar 429 e liberar. Cada trigger tem um cooldown próprio:
+            # - rest_api_429: 60s (REST API recupera mais devagar).
+            # - http_429: 15s (endpoint de tiles recupera mais rápido).
+            # `report_http_429` preserva um cooldown maior já ativo, garantindo
+            # que `report_429` chamado depois sempre vence — então o método
+            # certo precisa ser chamado de acordo com a origem do 429.
+            if trigger == "http_429":
+                self._pool.report_http_429(old_sa)
+            else:
+                self._pool.report_429(old_sa)
             self._pool.release(self._worker_id)
 
             # Adquirir nova SA (excluindo a atual)

--- a/app/core/gee_pool.py
+++ b/app/core/gee_pool.py
@@ -221,6 +221,14 @@ class ServiceAccountPool:
         sa_info = self._accounts[sa_name]
         sa_info.load_credentials()
 
+        # Auto-reset do gauge: SA atribuída por `acquire` significa que passou
+        # pelo filtro de cooldown — logo, está fora dele agora.
+        try:
+            from app.core.metrics import gee_sa_in_cooldown
+            gee_sa_in_cooldown.labels(sa_name=sa_name).set(0)
+        except Exception:
+            pass
+
         logger.info(f"Worker {worker_id} adquiriu SA {sa_name}")
         return sa_info
 
@@ -446,11 +454,17 @@ class WorkerGEEManager:
         )
         self._heartbeat_thread.start()
 
-    def rotate_on_429(self) -> None:
+    def rotate_on_429(self, trigger: str = "rest_api_429") -> None:
         """Rotaciona para uma nova SA após erro 429.
 
         Libera a SA atual, reporta o 429, adquire nova SA e re-inicializa.
         Thread-safe via RLock.
+
+        Args:
+            trigger: Origem do 429 — `"rest_api_429"` (default, chamadas via
+                ee_compute / @gee_retry) ou `"http_429"` (download de tile via
+                fetch_tile_with_rotation). Usado em métricas para discriminar
+                causas raiz com SLAs diferentes.
         """
         if not self._worker_id or not self._current_sa:
             logger.error("Tentativa de rotação sem inicialização prévia")
@@ -481,7 +495,7 @@ class WorkerGEEManager:
                 gee_sa_rotation_total.labels(
                     from_sa=old_sa,
                     to_sa=self._current_sa.name,
-                    trigger="http_429",
+                    trigger=trigger,
                 ).inc()
             except Exception:
                 pass

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -50,6 +50,8 @@ gee_sa_in_cooldown = Gauge(
     labelnames=("sa_name",),
 )
 
+# Counter instrumentado em app/utils/ee_tile_fetch.py (Task 4 do plano).
+# Definição vive aqui para manter as métricas do pool no mesmo módulo.
 gee_tile_url_regen_total = Counter(
     "gee_tile_url_regen_total",
     "Regenerações de URL do EE disparadas por 429, por layer",

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -5,7 +5,7 @@ ASGI que inspeciona status e header `X-Error-Reason` nas respostas.
 """
 from __future__ import annotations
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 
 # -- Registry -----------------------------------------------------------------
@@ -27,6 +27,33 @@ cache_hits_total = Counter(
     "cache_hits_total",
     "Outcome do cache por layer e tipo (png_hit, png_miss, meta_hit, meta_miss, neg_hit)",
     labelnames=("layer", "type"),
+)
+
+
+# -- Métricas do pool de Service Accounts do GEE ------------------------------
+
+gee_sa_http_429_total = Counter(
+    "gee_sa_http_429_total",
+    "Contagem de 429 do endpoint de tiles do EE por service account",
+    labelnames=("sa_name",),
+)
+
+gee_sa_rotation_total = Counter(
+    "gee_sa_rotation_total",
+    "Rotações de SA realizadas por trigger (http_429 ou rest_api_429)",
+    labelnames=("from_sa", "to_sa", "trigger"),
+)
+
+gee_sa_in_cooldown = Gauge(
+    "gee_sa_in_cooldown",
+    "1 se a SA está em cooldown por 429, 0 caso contrário",
+    labelnames=("sa_name",),
+)
+
+gee_tile_url_regen_total = Counter(
+    "gee_tile_url_regen_total",
+    "Regenerações de URL do EE disparadas por 429, por layer",
+    labelnames=("layer",),
 )
 
 

--- a/app/modules/embedding_maps/router.py
+++ b/app/modules/embedding_maps/router.py
@@ -26,6 +26,8 @@ from app.core.config import logger, settings
 from app.core.errors import generate_error_image
 from app.middleware.rate_limiter import limit_embedding
 from app.utils.http import http_get_bytes as _http_get_bytes
+from app.utils.ee_tile_fetch import fetch_tile_with_rotation
+from app.utils.http import EarthEngineRateLimitedError
 
 from . import repository
 from .schemas import (
@@ -277,45 +279,45 @@ async def serve_tile(
             > settings.get("LIFESPAN_URL", 24)
         )
 
+        # Extrair config do produto antes do branch — usado tanto na geração
+        # inicial quanto na regeneração por 429.
+        config = job.get("config", {})
+        roi_config = config.get("roi", {})
+        year = config.get("year", 2023)
+        processing = config.get("processing", {})
+        scale = processing.get("scale", 10)
+
+        product_cfg = {}
+        for p in config.get("products", []):
+            if p.get("product") == product:
+                product_cfg = p
+                break
+
+        def _build_and_get_url():
+            from .schemas import RoiConfig
+            roi = RoiConfig(**roi_config)
+            ee_roi = roi_to_ee_geometry(roi)
+            img = build_product_image(
+                year, ee_roi, product,
+                rgb_bands=product_cfg.get("rgb_bands"),
+                pca_components=product_cfg.get("pca_components", 3),
+                kmeans_k=product_cfg.get("kmeans_k", 8),
+                scale=scale,
+                sample_size=processing.get("sample_size", 5000),
+                year_b=product_cfg.get("year_b"),
+            )
+            vis = build_vis_params(
+                product,
+                palette=product_cfg.get("palette"),
+                vis_min=product_cfg.get("vis_min", -0.3),
+                vis_max=product_cfg.get("vis_max", 0.3),
+                kmeans_k=product_cfg.get("kmeans_k", 8),
+            )
+            return get_map_id_from_image(img, vis)
+
         if expired:
-            config = job.get("config", {})
-            roi_config = config.get("roi", {})
-            year = config.get("year", 2023)
-            processing = config.get("processing", {})
-            scale = processing.get("scale", 10)
-
-            # Encontrar config do produto especifico
-            product_cfg = {}
-            for p in config.get("products", []):
-                if p.get("product") == product:
-                    product_cfg = p
-                    break
-
             try:
-                loop = asyncio.get_event_loop()
-
-                def _build_and_get_url():
-                    from .schemas import RoiConfig
-                    roi = RoiConfig(**roi_config)
-                    ee_roi = roi_to_ee_geometry(roi)
-                    img = build_product_image(
-                        year, ee_roi, product,
-                        rgb_bands=product_cfg.get("rgb_bands"),
-                        pca_components=product_cfg.get("pca_components", 3),
-                        kmeans_k=product_cfg.get("kmeans_k", 8),
-                        scale=scale,
-                        sample_size=processing.get("sample_size", 5000),
-                        year_b=product_cfg.get("year_b"),
-                    )
-                    vis = build_vis_params(
-                        product,
-                        palette=product_cfg.get("palette"),
-                        vis_min=product_cfg.get("vis_min", -0.3),
-                        vis_max=product_cfg.get("vis_max", 0.3),
-                        kmeans_k=product_cfg.get("kmeans_k", 8),
-                    )
-                    return get_map_id_from_image(img, vis)
-
+                loop = asyncio.get_running_loop()
                 layer_url = await loop.run_in_executor(ee_executor, _build_and_get_url)
                 await set_meta(meta_key, {"url": layer_url, "date": datetime.now().isoformat()}, META_TTL)
             except Exception:
@@ -325,9 +327,19 @@ async def serve_tile(
         else:
             layer_url = meta["url"]
 
-        # 4. Download tile remoto
+        # 4. Download tile remoto via helper com rotação reativa.
+        async def _regenerate_url() -> str:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(ee_executor, _build_and_get_url)
+
         try:
-            png_bytes = await _http_get_bytes(layer_url.format(x=x, y=y, z=z))
+            png_bytes = await fetch_tile_with_rotation(
+                cache_key=meta_key,
+                cached_url=layer_url,
+                url_factory=_regenerate_url,
+                x=x, y=y, z=z,
+                layer="embedding_maps",
+            )
             await set_png(cache_key, png_bytes, PNG_TTL)
             elapsed = (time.monotonic() - t0) * 1000
             return StreamingResponse(
@@ -335,6 +347,13 @@ async def serve_tile(
                 media_type="image/png",
                 headers={"X-Cache-Status": "MISS", "X-Response-Time": f"{elapsed:.0f}ms"},
             )
+        except EarthEngineRateLimitedError:
+            logger.warning(
+                f"tile_embedding_maps_429_persistent job={job_id} product={product} "
+                f"action=return_503"
+            )
+            error_img = generate_error_image("EE rate limited")
+            return StreamingResponse(error_img, media_type="image/png", status_code=503)
         except HTTPException:
             logger.exception(f"Erro ao baixar tile para job {job_id}")
             error_img = generate_error_image("Erro ao baixar tile")

--- a/app/modules/embedding_maps/router.py
+++ b/app/modules/embedding_maps/router.py
@@ -25,7 +25,6 @@ from app.cache.cache import (
 from app.core.config import logger, settings
 from app.core.errors import generate_error_image
 from app.middleware.rate_limiter import limit_embedding
-from app.utils.http import http_get_bytes as _http_get_bytes
 from app.utils.ee_tile_fetch import fetch_tile_with_rotation
 from app.utils.http import EarthEngineRateLimitedError
 

--- a/app/utils/ee_tile_fetch.py
+++ b/app/utils/ee_tile_fetch.py
@@ -1,0 +1,104 @@
+"""Helper de busca de tile do Earth Engine com rotação reativa de SA.
+
+Resolve o caso onde a URL cacheada está vinculada a uma SA penalizada por
+429: a rotação isolada do worker não basta, porque o token na URL continua
+preso à SA antiga. Este helper orquestra o ciclo completo:
+
+1. Tenta o download com a URL cacheada.
+2. Em EarthEngineRateLimitedError:
+   a. Rotaciona a SA do worker (acquire SA diferente, libera a antiga).
+   b. Invalida o meta-cache da URL (delete_meta).
+   c. Chama o `url_factory()` do caller para regenerar a URL via getMapId
+      com a nova SA.
+   d. Persiste a nova URL no meta-cache (set_meta).
+   e. Tenta o download **uma única vez** com a nova URL.
+3. Segundo 429 → propaga `EarthEngineRateLimitedError` para o caller
+   converter em 503. Não tentamos terceira rodada porque getMapId custa
+   ~200–500ms e amplificar custa mais que entregar erro rápido.
+
+Idempotência: o ciclo é seguro em concorrência. Múltiplos workers podem
+invalidar a mesma chave; `delete_meta` é no-op em chave ausente. Múltiplas
+regenerações simultâneas geram URLs equivalentes — set_meta da última
+prevalece, sem perda funcional.
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+from datetime import datetime
+from typing import Awaitable, Callable
+
+from app.cache.cache import adelete_meta, aset_meta
+from app.core.config import logger
+from app.core.gee_auth import get_gee_manager
+from app.utils.http import EarthEngineRateLimitedError, http_get_bytes
+
+
+async def fetch_tile_with_rotation(
+    *,
+    cache_key: str,
+    cached_url: str,
+    url_factory: Callable[[], Awaitable[str]],
+    x: int,
+    y: int,
+    z: int,
+    layer: str,
+) -> bytes:
+    """Faz download do tile, com rotação reativa em caso de 429.
+
+    Args:
+        cache_key: Chave do meta-cache da URL (ex: "landsat_MONTH_2007_7_..."/<geohash>).
+        cached_url: URL template com placeholders {x}/{y}/{z}, lida do cache.
+        url_factory: Async callable que regenera a URL via getMapId. Deve
+            ser idempotente do ponto de vista do caller (encapsula geom/dates/vis).
+        x, y, z: Coordenadas do tile.
+        layer: Nome da camada (usado em métricas e logs).
+
+    Returns:
+        Bytes do PNG do tile.
+
+    Raises:
+        EarthEngineRateLimitedError: 429 persistente após uma rotação.
+        Qualquer outra exceção do `url_factory` ou de `http_get_bytes`.
+    """
+    try:
+        return await http_get_bytes(cached_url.format(x=x, y=y, z=z))
+    except EarthEngineRateLimitedError as exc:
+        sa_old = exc.sa_name or "<unknown>"
+        logger.warning(
+            f"sa_rotated_http_429 layer={layer} cache_key={cache_key} "
+            f"sa_from={sa_old} reason=tile_429"
+        )
+
+        manager = get_gee_manager()
+        if manager is not None:
+            # rotate_on_429 é síncrono (segura init_lock + ee.Initialize).
+            # Passa trigger="http_429" para diferenciar das rotações REST API
+            # nas métricas (gee_sa_rotation_total).
+            rotate = functools.partial(manager.rotate_on_429, trigger="http_429")
+            await asyncio.get_event_loop().run_in_executor(None, rotate)
+
+        # Invalidar a URL cacheada — assinada com a SA antiga.
+        try:
+            await adelete_meta(cache_key)
+        except Exception as del_exc:
+            logger.warning(f"Falha ao invalidar meta cache {cache_key}: {del_exc}")
+
+        # Regenerar a URL com a SA nova (via getMapId no url_factory).
+        new_url = await url_factory()
+
+        # Persistir a nova URL para próximos requests.
+        try:
+            await aset_meta(cache_key, {"url": new_url, "date": datetime.now().isoformat()})
+        except Exception as set_exc:
+            logger.warning(f"Falha ao persistir meta cache {cache_key}: {set_exc}")
+
+        # Métrica: regeneração disparada por 429.
+        try:
+            from app.core.metrics import gee_tile_url_regen_total
+            gee_tile_url_regen_total.labels(layer=layer).inc()
+        except Exception:
+            pass
+
+        # Retry único — segundo 429 propaga para o caller.
+        return await http_get_bytes(new_url.format(x=x, y=y, z=z))

--- a/app/utils/ee_tile_fetch.py
+++ b/app/utils/ee_tile_fetch.py
@@ -20,6 +20,16 @@ Idempotência: o ciclo é seguro em concorrência. Múltiplos workers podem
 invalidar a mesma chave; `delete_meta` é no-op em chave ausente. Múltiplas
 regenerações simultâneas geram URLs equivalentes — set_meta da última
 prevalece, sem perda funcional.
+
+Sobre `tile_lock` na regeneração: a spec mencionou aplicar lock distribuído
+ao redor do `url_factory()` para evitar thundering herd de `getMapId`
+sob saturação. A implementação atual NÃO usa lock — decisão deliberada
+para manter o helper genérico (sem dependência de tile_lock) e porque a
+regeneração só ocorre no path de exceção 429, que já é raro. Sob saturação
+extrema com N workers atingindo 429 simultaneamente, podem ocorrer N
+chamadas redundantes de `getMapId` (200–500ms cada), amplificando a carga
+no EE. Se a métrica `gee_tile_url_regen_total` mostrar volume sustentado,
+considerar adicionar lock distribuído como follow-up.
 """
 from __future__ import annotations
 

--- a/app/utils/ee_tile_fetch.py
+++ b/app/utils/ee_tile_fetch.py
@@ -65,24 +65,45 @@ async def fetch_tile_with_rotation(
         return await http_get_bytes(cached_url.format(x=x, y=y, z=z))
     except EarthEngineRateLimitedError as exc:
         sa_old = exc.sa_name or "<unknown>"
+
+        # Log de detecção do 429 — antes de qualquer ação. Diferenciado do
+        # log de rotação efetiva para evitar mentir sobre o que aconteceu.
         logger.warning(
-            f"sa_rotated_http_429 layer={layer} cache_key={cache_key} "
+            f"tile_429_detected layer={layer} cache_key={cache_key} "
             f"sa_from={sa_old} reason=tile_429"
         )
 
+        # Invalidar PRIMEIRO. Mesmo que a rotação falhe (saturação total
+        # do pool, Redis offline, ee.Initialize quebrado), o próximo request
+        # ainda regenera com SA fresca em vez de reusar a URL podre.
+        # delete_meta é idempotente — DEL em chave ausente é no-op.
+        try:
+            await adelete_meta(cache_key)
+        except Exception as del_exc:
+            logger.warning(f"Falha ao invalidar meta cache {cache_key}: {del_exc}")
+
+        # Tentar rotacionar a SA do worker.
         manager = get_gee_manager()
         if manager is not None:
             # rotate_on_429 é síncrono (segura init_lock + ee.Initialize).
             # Passa trigger="http_429" para diferenciar das rotações REST API
             # nas métricas (gee_sa_rotation_total).
             rotate = functools.partial(manager.rotate_on_429, trigger="http_429")
-            await asyncio.get_event_loop().run_in_executor(None, rotate)
-
-        # Invalidar a URL cacheada — assinada com a SA antiga.
-        try:
-            await adelete_meta(cache_key)
-        except Exception as del_exc:
-            logger.warning(f"Falha ao invalidar meta cache {cache_key}: {del_exc}")
+            try:
+                await asyncio.get_running_loop().run_in_executor(None, rotate)
+                logger.info(
+                    f"sa_rotated_http_429 layer={layer} sa_from={sa_old} "
+                    f"sa_to={manager.current_sa_name}"
+                )
+            except Exception as rot_exc:
+                # Rotação falhou — prossegue para regenerar URL na SA atual
+                # (que pode ser a mesma). É melhor tentar do que abortar:
+                # cache já foi invalidado, e a SA pode ter saído do cooldown
+                # entre o 429 e agora.
+                logger.warning(
+                    f"sa_rotation_failed layer={layer} sa_from={sa_old} "
+                    f"error={rot_exc}"
+                )
 
         # Regenerar a URL com a SA nova (via getMapId no url_factory).
         new_url = await url_factory()

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -10,7 +10,24 @@ import random
 import aiohttp
 from fastapi import HTTPException
 
-from app.core.config import logger
+from app.core.config import logger, settings
+
+
+class EarthEngineRateLimitedError(Exception):
+    """Sinaliza 429 persistente do endpoint de tiles do Earth Engine.
+
+    O caller usa essa exceção para acionar rotação de SA + invalidação de
+    URL cacheada + regeneração. Diferencia 429 (recuperável) de falhas HTTP
+    genéricas (irrecuperáveis no mesmo request).
+
+    `sa_name` carrega o nome da SA penalizada quando disponível; útil para
+    logs estruturados no caller. Pode ser None se não houver gee_manager
+    ativo (ex: testes, modo dev).
+    """
+
+    def __init__(self, message: str, sa_name: str | None = None):
+        super().__init__(message)
+        self.sa_name = sa_name
 
 
 async def http_get_bytes(
@@ -18,19 +35,25 @@ async def http_get_bytes(
     *,
     max_retries: int = 3,
     base_delay: float = 1.0,
-    timeout: float = 10.0,
+    timeout: float | None = None,
 ) -> bytes:
     """Faz download de bytes via HTTP GET com retry e backoff exponencial.
 
-    Trata 429 (rate limit) com backoff exponencial + jitter.
-    Retorna os bytes da resposta em caso de 200.
+    Trata 429 (rate limit) com backoff exponencial + jitter. Retorna os
+    bytes da resposta em caso de 200.
 
     Parâmetros:
-    - `max_retries`: reduzido de 5 para 3 (PR #5) — retry excessivo amplifica
-      carga no EE sob degradação sem melhorar taxa de sucesso.
-    - `timeout`: total em segundos por tentativa. Sem timeout explícito o
-      worker trava em EE lento, esgota o thread pool.
+    - `max_retries`: 3 (PR #5) — retry excessivo amplifica carga no EE.
+    - `timeout`: total em segundos por tentativa. Default lê
+      `settings.HTTP_GET_BYTES_TIMEOUT` (20 s) — antes era hard-coded 10 s,
+      insuficiente sob carga.
+
+    Em 429 persistente, lança `EarthEngineRateLimitedError` carregando o
+    nome da SA atual (quando há gee_manager ativo). O caller é responsável
+    por rotacionar a SA + invalidar o cache de URL + regenerar via getMapId.
     """
+    if timeout is None:
+        timeout = settings.get("HTTP_GET_BYTES_TIMEOUT", 20.0)
     client_timeout = aiohttp.ClientTimeout(total=timeout)
 
     for attempt in range(max_retries):
@@ -39,12 +62,15 @@ async def http_get_bytes(
                 if resp.status == 200:
                     return await resp.read()
                 elif resp.status == 429:
-                    # Registrar métrica no pool (sem rotação — URL já gerada)
+                    # Registrar métrica fire-and-forget. A rotação da SA fica
+                    # com o caller, que tem o contexto da URL e do cache key.
+                    sa_name: str | None = None
                     try:
                         from app.core.gee_auth import get_gee_manager
                         mgr = get_gee_manager()
                         if mgr:
                             mgr.report_http_429()
+                            sa_name = mgr.current_sa_name
                     except Exception:
                         pass
 
@@ -58,10 +84,9 @@ async def http_get_bytes(
                         continue
                     else:
                         logger.error("Max retries reached for rate limiting")
-                        raise HTTPException(
-                            status_code=503,
-                            detail="Earth Engine temporarily unavailable due to rate limiting. "
-                                   "Please try again in a few seconds.",
+                        raise EarthEngineRateLimitedError(
+                            "Earth Engine rate-limited after retries",
+                            sa_name=sa_name,
                         )
                 else:
                     raise HTTPException(resp.status, f"Erro ao buscar recurso: {resp.reason}")

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -124,6 +124,45 @@ ssh prod-lapig 'docker exec $(docker ps -qf name=valkey | head -1) \
   redis-cli DEL cb:ee:open_until'
 ```
 
+## Purge continuado via Celery beat (recomendado)
+
+Execução manual ampla do `purge_poisoned_tiles.py` causou contenção no
+Valkey (latência 2× em batches sequenciais, taxa de 5xx subiu de 2,7 % para
+10 % durante a operação). A limpeza total deve ser feita em janelas de
+baixa carga.
+
+**Recomendação:** Celery beat diário às 03:00 BRT com batch pequeno e
+scan não-agressivo:
+
+```python
+# app/tasks/tile.py
+@celery_app.task(name="tiles.purge_poisoned_nightly")
+def purge_poisoned_nightly():
+    """Remove 50k tiles envenenados por execução (≤ 30 min de Valkey pressure)."""
+    import subprocess
+    subprocess.run([
+        "python", "/app/scripts/purge_poisoned_tiles.py",
+        "--apply",
+        "--limit", "50000",
+        "--scan-count", "500",   # menos agressivo que o manual (5000)
+    ], check=False)
+
+# celery beat schedule (settings.toml ou celery config)
+# purge-poisoned-nightly:
+#   task: tiles.purge_poisoned_nightly
+#   schedule: crontab(hour=3, minute=0)
+```
+
+**Expectativa:** ~100k envenenadas removidas a cada 2 dias (beat + cache
+expirando naturalmente em 30d). Estoque de ~700k deve zerar em ≤ 14 dias.
+
+**Monitorar:** adicionar painel Grafana com `DBSIZE` e `used_memory_human`
+do Valkey; alerta se `DBSIZE` não decrescer ~50k/dia.
+
+**Desativar após limpeza**: quando métrica `tiles_poisoned_count` cair para
+< 1000, remover o beat (sem mais utilidade — fixes do deploy impedem
+novos placeholders).
+
 ## Rollback
 
 Em caso de regressão grave (quebra de UX, explosão de erro sustentada):
@@ -138,3 +177,43 @@ Os tiles transparentes criados pelo `_empty_image_with_bands` continuarão em ca
 ## Contato
 
 Em caso de dúvida durante deploy, escalar para o time de backend antes de aplicar rollback.
+
+## Expansão do pool de Service Accounts do GEE
+
+A taxa de 503 (`ee_unavailable`) sob carga é limitada pela cota das SAs
+ativas no pool, não pelo código. O fix de rotação reativa (entrega de
+2026-05-12) mitiga picos transitórios; o teto sustentável depende do
+número de SAs com cota disponível.
+
+### Sintomas que indicam saturação de capacidade
+
+- Métrica `gee_sa_rotation_total` cresce continuamente, sem estabilizar.
+- Métrica `gee_sa_in_cooldown` mostra todas as SAs alternando em cooldown.
+- `gee_tile_url_regen_total` alto e sustentado — confirma que 429 não é
+  pico transitório, é teto de capacidade.
+
+### Ação operacional
+
+1. Provisionar SAs adicionais no GCP Console (projeto `earthengine-legacy`
+   ou equivalente). Cada SA tem cota independente no endpoint de tiles.
+2. Baixar o JSON da nova SA e depositar em `.service-accounts/`:
+   ```bash
+   scp nova-sa.json prod-lapig:/path/to/.service-accounts/
+   ```
+3. Hot-reload do pool — sem necessidade de redeploy:
+   ```bash
+   curl -X POST http://localhost:8080/admin/gee-pool/refresh
+   ```
+4. Verificar que a nova SA foi descoberta:
+   ```bash
+   curl http://localhost:8080/admin/gee-pool/metrics
+   ```
+5. Acompanhar `gee_sa_http_429_total` por SA: distribuição deve ficar
+   mais equilibrada à medida que o pool absorve a carga.
+
+### Quando reduzir a frota
+
+Se `gee_sa_in_cooldown` raramente passa de 0 e `gee_sa_rotation_total`
+fica estagnado por dias seguidos, há overprovisionamento. SAs ociosas
+não custam, mas complicam a rotação dos JSONs — manter o pool em
+tamanho mínimo necessário para sustentar o pico observado.

--- a/docs/superpowers/plans/2026-05-12-tiles-ee-429-rotation-cache-invalidation.md
+++ b/docs/superpowers/plans/2026-05-12-tiles-ee-429-rotation-cache-invalidation.md
@@ -1,0 +1,1439 @@
+# Mitigação de 429 do Earth Engine — Plano de Implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminar a maior parte dos 503 (`ee_unavailable`) servidos a partir do endpoint de tiles, fazendo o pool de Service Accounts do GEE reagir a 429 de download HTTP com rotação reativa, invalidação da URL cacheada e regeneração via `getMapId` com SA fresca.
+
+**Architecture:** `http_get_bytes` permanece agnóstico de GEE mas passa a lançar uma exceção tipada (`EarthEngineRateLimitedError`). Um novo helper `fetch_tile_with_rotation` orquestra: rotação da SA do worker, invalidação do meta-cache da URL, regeneração via `url_factory()` e um único retry. As três call sites (`layers.py`, `imagery.py`, `embedding_maps/router.py`) adotam o helper. Timeout do download sobe de 10 s para 20 s, configurável. Counters Prometheus por SA são adicionados para observabilidade.
+
+**Tech Stack:** Python 3.12, FastAPI, aiohttp, Redis (Valkey), Prometheus (`prometheus_client`), pytest + pytest-asyncio.
+
+**Spec de referência:** `docs/superpowers/specs/2026-05-12-tiles-ee-429-rotation-cache-invalidation-design.md`.
+
+---
+
+## Mapa de arquivos
+
+| Arquivo | Operação | Responsabilidade |
+|---|---|---|
+| `settings.toml` | edit | Adicionar `HTTP_GET_BYTES_TIMEOUT = 20` |
+| `app/cache/cache.py` | edit | Adicionar `adelete_meta(key)` (assíncrono) |
+| `app/cache/cache_hybrid.py` | edit | Adicionar método `delete_meta(key)` ao `tile_cache` |
+| `app/utils/http.py` | edit | Exceção tipada `EarthEngineRateLimitedError`; timeout default 20 s |
+| `app/core/gee_pool.py` | edit | Counters Prometheus por SA; ganchos em `report_http_429` e `rotate_on_429` |
+| `app/utils/ee_tile_fetch.py` | new | Helper `fetch_tile_with_rotation` |
+| `app/api/layers.py` | edit | `_serve_tile` adota helper |
+| `app/api/imagery.py` | edit | Tile handler adota helper |
+| `app/modules/embedding_maps/router.py` | edit | Tile handler adota helper |
+| `docs/deploy-runbook.md` | edit | Seção de expansão do pool de SAs |
+| `tests/unit/test_http_retries_reduced.py` | edit | Atualizar limite superior do timeout |
+| `tests/unit/test_http_typed_exception.py` | new | Cobre `EarthEngineRateLimitedError` |
+| `tests/unit/test_ee_tile_fetch.py` | new | Cobre o helper de rotação |
+| `tests/unit/test_gee_pool_metrics.py` | new | Cobre os counters Prometheus |
+| `tests/unit/test_cache_delete_meta.py` | new | Cobre `adelete_meta` |
+
+---
+
+## Task 1: Configuração `HTTP_GET_BYTES_TIMEOUT` e `adelete_meta`
+
+**Files:**
+- Modify: `settings.toml`
+- Modify: `app/cache/cache_hybrid.py` (classe `tile_cache`)
+- Modify: `app/cache/cache.py` (façade)
+- Test: `tests/unit/test_cache_delete_meta.py`
+
+- [ ] **Step 1: Escrever teste falhando para `adelete_meta`**
+
+Arquivo: `tests/unit/test_cache_delete_meta.py`
+
+```python
+"""adelete_meta — invalida URL cacheada após 429 da SA. Sem isso,
+workers continuam lendo URL acoplada à SA penalizada."""
+from __future__ import annotations
+
+import pytest
+
+from app.cache import cache as cache_mod
+
+
+@pytest.mark.asyncio
+async def test_adelete_meta_is_async_callable():
+    """A função existe e é assíncrona — caller usa `await adelete_meta(...)`."""
+    import inspect
+    assert hasattr(cache_mod, "adelete_meta")
+    assert inspect.iscoroutinefunction(cache_mod.adelete_meta)
+```
+
+- [ ] **Step 2: Rodar o teste e confirmar falha**
+
+```bash
+cd /home/tharles/projects_lapig/tiles
+pytest tests/unit/test_cache_delete_meta.py -v
+```
+
+Esperado: `AttributeError: module 'app.cache.cache' has no attribute 'adelete_meta'`.
+
+- [ ] **Step 3: Implementar `delete_meta` no `tile_cache`**
+
+Editar `app/cache/cache_hybrid.py`, logo após o método `set_meta` (próximo à linha 299):
+
+```python
+    async def delete_meta(self, key: str) -> None:
+        """Remove metadados (URL EE etc.) do Redis. Usado para invalidar
+        URLs cacheadas vinculadas a SAs penalizadas por 429.
+
+        Idempotente — DEL em chave inexistente é no-op no Redis.
+        """
+        async with self._get_redis() as r:
+            await r.delete(f"meta:{key}")
+```
+
+- [ ] **Step 4: Adicionar façade `adelete_meta` em `app/cache/cache.py`**
+
+Inserir após a definição de `aset_meta` (logo antes de `def atile_lock`):
+
+```python
+async def adelete_meta(key: str) -> None:
+    """Remove metadados do cache híbrido (assíncrono).
+
+    Usado pelo helper de rotação para invalidar URLs do EE quando a SA
+    que as assinou recebeu 429.
+    """
+    await tile_cache.delete_meta(key)
+```
+
+- [ ] **Step 5: Rodar o teste e confirmar que passa**
+
+```bash
+pytest tests/unit/test_cache_delete_meta.py -v
+```
+
+Esperado: `1 passed`.
+
+- [ ] **Step 6: Adicionar `HTTP_GET_BYTES_TIMEOUT` ao `settings.toml`**
+
+Inserir após a linha `LIFESPAN_URL = 24` no bloco `[default]`:
+
+```toml
+# Timeout total (segundos) por tentativa de download de tile do EE.
+# 10s era insuficiente sob carga (EE responde em 8–12s); 20s reduz
+# TimeoutErrors sem prolongar excessivamente requests com EE realmente lento.
+HTTP_GET_BYTES_TIMEOUT = 20
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add settings.toml app/cache/cache.py app/cache/cache_hybrid.py tests/unit/test_cache_delete_meta.py
+git commit -m "feat(tiles): adiciona adelete_meta e settings HTTP_GET_BYTES_TIMEOUT"
+```
+
+---
+
+## Task 2: Exceção tipada `EarthEngineRateLimitedError` em `http.py`
+
+**Files:**
+- Modify: `app/utils/http.py`
+- Test: `tests/unit/test_http_typed_exception.py`
+
+- [ ] **Step 1: Escrever teste falhando para a exceção tipada**
+
+Arquivo: `tests/unit/test_http_typed_exception.py`
+
+```python
+"""http_get_bytes deve lançar EarthEngineRateLimitedError ao esgotar retries
+em 429 — permite que o caller diferencie 429 (recuperável via rotação) de
+falhas HTTP genéricas (irrecuperáveis)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.utils import http as http_mod
+from app.utils.http import EarthEngineRateLimitedError, http_get_bytes
+
+
+def _fake_aiohttp_session(status: int):
+    """Constrói um ClientSession fake cujo .get(...) devolve um response
+    com o status pedido. Suporta o padrão `async with session.get(...) as r`."""
+    resp = MagicMock()
+    resp.status = status
+    resp.read = AsyncMock(return_value=b"")
+    resp.reason = "Too Many Requests"
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=None)
+
+    sess = MagicMock()
+    sess.get = MagicMock(return_value=resp)
+    sess.__aenter__ = AsyncMock(return_value=sess)
+    sess.__aexit__ = AsyncMock(return_value=None)
+    return sess
+
+
+@pytest.mark.asyncio
+async def test_exception_class_exists_and_carries_sa_name():
+    """EarthEngineRateLimitedError é exportada e aceita sa_name opcional."""
+    exc = EarthEngineRateLimitedError("rate limited", sa_name="sa-x@proj")
+    assert isinstance(exc, Exception)
+    assert exc.sa_name == "sa-x@proj"
+
+
+@pytest.mark.asyncio
+async def test_persistent_429_raises_typed_exception():
+    """Após esgotar todas as tentativas com 429, deve subir
+    EarthEngineRateLimitedError — não HTTPException."""
+    fake = _fake_aiohttp_session(status=429)
+
+    with patch("app.utils.http.aiohttp.ClientSession", return_value=fake):
+        with pytest.raises(EarthEngineRateLimitedError):
+            await http_get_bytes(
+                "http://example.com/tile.png",
+                max_retries=2,
+                base_delay=0.0,
+            )
+```
+
+- [ ] **Step 2: Rodar e confirmar falha**
+
+```bash
+pytest tests/unit/test_http_typed_exception.py -v
+```
+
+Esperado: `ImportError: cannot import name 'EarthEngineRateLimitedError' from 'app.utils.http'`.
+
+- [ ] **Step 3: Definir a exceção em `app/utils/http.py`**
+
+Editar `app/utils/http.py`. Substituir o bloco inteiro (linhas 1–79) por:
+
+```python
+"""
+Utilitário HTTP compartilhado para download de imagens do Earth Engine.
+Extraído de layers.py para reuso entre módulos (tiles, imagery).
+"""
+from __future__ import annotations
+
+import asyncio
+import random
+
+import aiohttp
+from fastapi import HTTPException
+
+from app.core.config import logger, settings
+
+
+class EarthEngineRateLimitedError(Exception):
+    """Sinaliza 429 persistente do endpoint de tiles do Earth Engine.
+
+    O caller usa essa exceção para acionar rotação de SA + invalidação de
+    URL cacheada + regeneração. Diferencia 429 (recuperável) de falhas HTTP
+    genéricas (irrecuperáveis no mesmo request).
+
+    `sa_name` carrega o nome da SA penalizada quando disponível; útil para
+    logs estruturados no caller. Pode ser None se não houver gee_manager
+    ativo (ex: testes, modo dev).
+    """
+
+    def __init__(self, message: str, sa_name: str | None = None):
+        super().__init__(message)
+        self.sa_name = sa_name
+
+
+async def http_get_bytes(
+    url: str,
+    *,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    timeout: float | None = None,
+) -> bytes:
+    """Faz download de bytes via HTTP GET com retry e backoff exponencial.
+
+    Trata 429 (rate limit) com backoff exponencial + jitter. Retorna os
+    bytes da resposta em caso de 200.
+
+    Parâmetros:
+    - `max_retries`: 3 (PR #5) — retry excessivo amplifica carga no EE.
+    - `timeout`: total em segundos por tentativa. Default lê
+      `settings.HTTP_GET_BYTES_TIMEOUT` (20 s) — antes era hard-coded 10 s,
+      insuficiente sob carga.
+
+    Em 429 persistente, lança `EarthEngineRateLimitedError` carregando o
+    nome da SA atual (quando há gee_manager ativo). O caller é responsável
+    por rotacionar a SA + invalidar o cache de URL + regenerar via getMapId.
+    """
+    if timeout is None:
+        timeout = settings.get("HTTP_GET_BYTES_TIMEOUT", 20.0)
+    client_timeout = aiohttp.ClientTimeout(total=timeout)
+
+    for attempt in range(max_retries):
+        try:
+            async with aiohttp.ClientSession(timeout=client_timeout) as sess, sess.get(url) as resp:
+                if resp.status == 200:
+                    return await resp.read()
+                elif resp.status == 429:
+                    # Registrar métrica fire-and-forget. A rotação da SA fica
+                    # com o caller, que tem o contexto da URL e do cache key.
+                    sa_name: str | None = None
+                    try:
+                        from app.core.gee_auth import get_gee_manager
+                        mgr = get_gee_manager()
+                        if mgr:
+                            mgr.report_http_429()
+                            sa_name = mgr.current_sa_name
+                    except Exception:
+                        pass
+
+                    if attempt < max_retries - 1:
+                        delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
+                        logger.warning(
+                            f"Rate limited (429). Retrying in {delay:.1f}s… "
+                            f"(attempt {attempt + 1}/{max_retries})"
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                    else:
+                        logger.error("Max retries reached for rate limiting")
+                        raise EarthEngineRateLimitedError(
+                            "Earth Engine rate-limited after retries",
+                            sa_name=sa_name,
+                        )
+                else:
+                    raise HTTPException(resp.status, f"Erro ao buscar recurso: {resp.reason}")
+        except aiohttp.ClientError as e:
+            if attempt < max_retries - 1:
+                delay = base_delay * (2 ** attempt)
+                logger.warning(f"Connection error: {e}. Retrying in {delay:.1f}s…")
+                await asyncio.sleep(delay)
+                continue
+            else:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Unable to connect to Earth Engine service",
+                )
+```
+
+- [ ] **Step 4: Rodar testes e confirmar que passam**
+
+```bash
+pytest tests/unit/test_http_typed_exception.py -v
+```
+
+Esperado: `2 passed`.
+
+- [ ] **Step 5: Atualizar `tests/unit/test_http_retries_reduced.py`**
+
+O teste atual cobre apenas o default 10 s; o novo default é 20 s e o timeout é resolvido em runtime via settings. Substituir o conteúdo por:
+
+```python
+"""PR #5: retries default de `http_get_bytes` foi reduzido de 5 para 3 e
+timeout explícito foi adicionado à sessão aiohttp. A partir do fix de 429
+de 2026-05-12, o timeout default é resolvido via `settings.HTTP_GET_BYTES_TIMEOUT`
+(20 s)."""
+from __future__ import annotations
+
+import inspect
+
+from app.utils import http as http_mod
+
+
+def test_default_max_retries_is_three():
+    """5 retries é excessivo; 3 cobre flakiness transitório sem amplificar
+    carga no EE sob degradação."""
+    sig = inspect.signature(http_mod.http_get_bytes)
+    assert sig.parameters["max_retries"].default == 3
+
+
+def test_timeout_parameter_present():
+    """Sem timeout, worker fica pendurado em EE lento — esgota o thread pool."""
+    sig = inspect.signature(http_mod.http_get_bytes)
+    assert "timeout" in sig.parameters
+
+
+def test_default_timeout_resolves_to_twenty_seconds():
+    """Default é resolvido em runtime via settings.HTTP_GET_BYTES_TIMEOUT;
+    a constante esperada é 20 s — margem para EE responder em 8–12 s sob carga."""
+    from app.core.config import settings
+    assert settings.get("HTTP_GET_BYTES_TIMEOUT", 20.0) == 20
+```
+
+- [ ] **Step 6: Rodar a suite completa de http**
+
+```bash
+pytest tests/unit/test_http_retries_reduced.py tests/unit/test_http_typed_exception.py -v
+```
+
+Esperado: `5 passed` (3 do reduced + 2 do typed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/utils/http.py tests/unit/test_http_typed_exception.py tests/unit/test_http_retries_reduced.py
+git commit -m "feat(tiles): EarthEngineRateLimitedError tipada e timeout default 20s em http_get_bytes"
+```
+
+---
+
+## Task 3: Counters Prometheus por SA em `gee_pool.py`
+
+**Files:**
+- Modify: `app/core/metrics.py` (novos counters/gauges)
+- Modify: `app/core/gee_pool.py` (instrumentação em `report_http_429`, `report_429`, `rotate_on_429`)
+- Test: `tests/unit/test_gee_pool_metrics.py`
+
+- [ ] **Step 1: Escrever teste falhando para os novos counters**
+
+Arquivo: `tests/unit/test_gee_pool_metrics.py`
+
+```python
+"""Counters Prometheus por SA são essenciais para diagnosticar oscilação
+entre SAs e capacidade de cota — sintoma escondido sem essa observabilidade."""
+from __future__ import annotations
+
+from prometheus_client import REGISTRY
+
+
+def _read_counter(name: str, **labels: str) -> float:
+    """Lê o valor atual de um counter Prometheus com os labels dados."""
+    value = REGISTRY.get_sample_value(name, labels=labels)
+    return value if value is not None else 0.0
+
+
+def test_gee_sa_http_429_total_counter_exists():
+    """gee_sa_http_429_total — contador por SA penalizada por 429 de tile."""
+    from app.core import metrics  # noqa: F401
+    val = _read_counter("gee_sa_http_429_total", sa_name="probe-sa@proj")
+    assert val == 0.0  # counter inicia em 0
+
+
+def test_gee_sa_rotation_total_counter_exists():
+    """gee_sa_rotation_total — contador de rotações por origem/destino/trigger."""
+    from app.core import metrics  # noqa: F401
+    val = _read_counter(
+        "gee_sa_rotation_total",
+        from_sa="probe-from",
+        to_sa="probe-to",
+        trigger="http_429",
+    )
+    assert val == 0.0
+
+
+def test_gee_sa_in_cooldown_gauge_exists():
+    """gee_sa_in_cooldown — gauge 0/1 por SA, útil para alerta de capacidade."""
+    from app.core import metrics  # noqa: F401
+    val = REGISTRY.get_sample_value(
+        "gee_sa_in_cooldown", labels={"sa_name": "probe-sa@proj"}
+    )
+    # Gauge não inicializado retorna None; teste só valida que o nome existe
+    # via uma chamada subsequente.
+    metrics.gee_sa_in_cooldown.labels(sa_name="probe-sa@proj").set(0)
+    val = REGISTRY.get_sample_value(
+        "gee_sa_in_cooldown", labels={"sa_name": "probe-sa@proj"}
+    )
+    assert val == 0.0
+```
+
+- [ ] **Step 2: Rodar e confirmar falha**
+
+```bash
+pytest tests/unit/test_gee_pool_metrics.py -v
+```
+
+Esperado: falhas porque os counters não existem.
+
+- [ ] **Step 3: Adicionar counters em `app/core/metrics.py`**
+
+**3a.** Atualizar a linha 8 de `app/core/metrics.py`:
+
+Antes:
+```python
+from prometheus_client import Counter, Histogram
+```
+
+Depois:
+```python
+from prometheus_client import Counter, Gauge, Histogram
+```
+
+**3b.** Após a definição de `cache_hits_total` (~linha 30), inserir o novo bloco:
+
+```python
+
+
+# -- Métricas do pool de Service Accounts do GEE ------------------------------
+
+gee_sa_http_429_total = Counter(
+    "gee_sa_http_429_total",
+    "Contagem de 429 do endpoint de tiles do EE por service account",
+    labelnames=("sa_name",),
+)
+
+gee_sa_rotation_total = Counter(
+    "gee_sa_rotation_total",
+    "Rotações de SA realizadas por trigger (http_429 ou rest_api_429)",
+    labelnames=("from_sa", "to_sa", "trigger"),
+)
+
+gee_sa_in_cooldown = Gauge(
+    "gee_sa_in_cooldown",
+    "1 se a SA está em cooldown por 429, 0 caso contrário",
+    labelnames=("sa_name",),
+)
+
+gee_tile_url_regen_total = Counter(
+    "gee_tile_url_regen_total",
+    "Regenerações de URL do EE disparadas por 429, por layer",
+    labelnames=("layer",),
+)
+```
+
+- [ ] **Step 4: Instrumentar `report_http_429` em `gee_pool.py`**
+
+Editar `app/core/gee_pool.py`. Localizar `report_http_429` (linha 259) e adicionar instrumentação ao final do método, antes do `return`:
+
+Trecho original (linhas 284–288):
+```python
+        pipe = self._redis.pipeline()
+        pipe.hincrby(metrics_key, "errors_429", 1)
+        pipe.hset(metrics_key, "last_429_at", str(now))
+        pipe.hset(metrics_key, "cooldown_until", str(new_cooldown_end))
+        pipe.execute()
+```
+
+Substituir por:
+```python
+        pipe = self._redis.pipeline()
+        pipe.hincrby(metrics_key, "errors_429", 1)
+        pipe.hset(metrics_key, "last_429_at", str(now))
+        pipe.hset(metrics_key, "cooldown_until", str(new_cooldown_end))
+        pipe.execute()
+
+        try:
+            from app.core.metrics import gee_sa_http_429_total, gee_sa_in_cooldown
+            gee_sa_http_429_total.labels(sa_name=sa_name).inc()
+            gee_sa_in_cooldown.labels(sa_name=sa_name).set(1)
+        except Exception:
+            # Métrica é best-effort — falha de instrumentação não pode
+            # quebrar a rotação que é caminho crítico.
+            pass
+```
+
+E no branch de cooldown preservado (linhas 273–282), também incrementar o counter de 429:
+
+Trecho original:
+```python
+        existing = self._redis.hget(metrics_key, "cooldown_until")
+        if existing:
+            try:
+                if float(existing) > new_cooldown_end:
+                    pipe = self._redis.pipeline()
+                    pipe.hincrby(metrics_key, "errors_429", 1)
+                    pipe.hset(metrics_key, "last_429_at", str(now))
+                    pipe.execute()
+                    return
+            except ValueError:
+                pass
+```
+
+Substituir por:
+```python
+        existing = self._redis.hget(metrics_key, "cooldown_until")
+        if existing:
+            try:
+                if float(existing) > new_cooldown_end:
+                    pipe = self._redis.pipeline()
+                    pipe.hincrby(metrics_key, "errors_429", 1)
+                    pipe.hset(metrics_key, "last_429_at", str(now))
+                    pipe.execute()
+                    try:
+                        from app.core.metrics import gee_sa_http_429_total
+                        gee_sa_http_429_total.labels(sa_name=sa_name).inc()
+                    except Exception:
+                        pass
+                    return
+            except ValueError:
+                pass
+```
+
+- [ ] **Step 5: Instrumentar `rotate_on_429` em `gee_pool.py`**
+
+Localizar `WorkerGEEManager.rotate_on_429` (linha 430). Após o log `Worker {self._worker_id} rotacionou: ...` (linha 456–459), adicionar:
+
+```python
+            try:
+                from app.core.metrics import gee_sa_rotation_total
+                gee_sa_rotation_total.labels(
+                    from_sa=old_sa,
+                    to_sa=self._current_sa.name,
+                    trigger="http_429",
+                ).inc()
+            except Exception:
+                pass
+```
+
+Nota: o decorator `@gee_retry` (REST API) chama `rotate_on_429` também. Por hora, todas as rotações são contadas como `trigger="http_429"`. Refinamento por trigger fica como follow-up — apenas o cenário de tiles é alvo desta entrega.
+
+- [ ] **Step 6: Atualizar gauge de cooldown quando libera**
+
+Em `report_429` (síncrono via REST API) e ao final do cooldown natural, o gauge precisaria voltar para 0. Como o cooldown expira por timestamp em Redis (não há hook ao expirar), a forma prática é o `get_metrics()` (linha 333) atualizar o gauge ao ser consultado. Editar o loop dentro de `get_metrics` (linha 340):
+
+Trecho original:
+```python
+        for sa_name in self._accounts:
+            score = self._redis.zscore(self._KEY_POOL, sa_name) or 0
+            metrics_key = self._KEY_METRICS.format(sa_name)
+            metrics = self._redis.hgetall(metrics_key)
+
+            cooldown_until = metrics.get("cooldown_until", "")
+            now = time.time()
+            in_cooldown = bool(
+                cooldown_until and cooldown_until != "" and float(cooldown_until) > now
+            )
+```
+
+Adicionar logo após `in_cooldown = ...`:
+```python
+            try:
+                from app.core.metrics import gee_sa_in_cooldown
+                gee_sa_in_cooldown.labels(sa_name=sa_name).set(1 if in_cooldown else 0)
+            except Exception:
+                pass
+```
+
+- [ ] **Step 7: Rodar testes e confirmar que passam**
+
+```bash
+pytest tests/unit/test_gee_pool_metrics.py -v
+```
+
+Esperado: `3 passed`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/core/metrics.py app/core/gee_pool.py tests/unit/test_gee_pool_metrics.py
+git commit -m "feat(tiles): counters Prometheus por SA do pool GEE [#5]"
+```
+
+---
+
+## Task 4: Helper `fetch_tile_with_rotation`
+
+**Files:**
+- Create: `app/utils/ee_tile_fetch.py`
+- Test: `tests/unit/test_ee_tile_fetch.py`
+
+- [ ] **Step 1: Escrever testes falhando**
+
+Arquivo: `tests/unit/test_ee_tile_fetch.py`
+
+```python
+"""Cobre o helper que orquestra rotação de SA + invalidação de cache +
+regeneração de URL em 429 do download de tile.
+
+Caminho feliz: passthrough simples para http_get_bytes.
+Caminho de erro: 429 → rotate + delete_meta + url_factory + retry único.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.utils.http import EarthEngineRateLimitedError
+
+
+@pytest.fixture
+def fake_manager():
+    mgr = MagicMock()
+    mgr.current_sa_name = "sa-old@proj"
+    mgr.rotate_on_429 = MagicMock(
+        side_effect=lambda: setattr(mgr, "current_sa_name", "sa-new@proj")
+    )
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_happy_path_no_rotation(fake_manager):
+    """200 no primeiro shot — não rotaciona, não invalida cache, não regenera."""
+    from app.utils import ee_tile_fetch
+
+    url_factory = AsyncMock()
+
+    with patch.object(ee_tile_fetch, "http_get_bytes", AsyncMock(return_value=b"PNG")) as fake_get, \
+         patch.object(ee_tile_fetch, "adelete_meta", AsyncMock()) as fake_del, \
+         patch.object(ee_tile_fetch, "aset_meta", AsyncMock()) as fake_set, \
+         patch.object(ee_tile_fetch, "get_gee_manager", return_value=fake_manager):
+
+        result = await ee_tile_fetch.fetch_tile_with_rotation(
+            cache_key="landsat_MONTH_2007_7_landsat-tvi-false/abc",
+            cached_url="https://ee.googleapis.com/.../{z}/{x}/{y}",
+            url_factory=url_factory,
+            x=1, y=2, z=10,
+            layer="landsat",
+        )
+
+    assert result == b"PNG"
+    fake_get.assert_awaited_once()
+    url_factory.assert_not_called()
+    fake_del.assert_not_called()
+    fake_set.assert_not_called()
+    fake_manager.rotate_on_429.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_429_triggers_full_rotation_cycle(fake_manager):
+    """429 na primeira chamada → rotate + delete_meta + url_factory + retry."""
+    from app.utils import ee_tile_fetch
+
+    url_factory = AsyncMock(return_value="https://ee.googleapis.com/.../new/{z}/{x}/{y}")
+
+    # Primeira chamada lança 429; segunda devolve bytes.
+    fake_get = AsyncMock(side_effect=[
+        EarthEngineRateLimitedError("rate limited", sa_name="sa-old@proj"),
+        b"PNG-NEW",
+    ])
+
+    with patch.object(ee_tile_fetch, "http_get_bytes", fake_get), \
+         patch.object(ee_tile_fetch, "adelete_meta", AsyncMock()) as fake_del, \
+         patch.object(ee_tile_fetch, "aset_meta", AsyncMock()) as fake_set, \
+         patch.object(ee_tile_fetch, "get_gee_manager", return_value=fake_manager):
+
+        result = await ee_tile_fetch.fetch_tile_with_rotation(
+            cache_key="landsat_MONTH_2007_7_landsat-tvi-false/abc",
+            cached_url="https://ee.googleapis.com/.../old/{z}/{x}/{y}",
+            url_factory=url_factory,
+            x=1, y=2, z=10,
+            layer="landsat",
+        )
+
+    assert result == b"PNG-NEW"
+    assert fake_get.await_count == 2
+    fake_manager.rotate_on_429.assert_called_once()
+    fake_del.assert_awaited_once_with("landsat_MONTH_2007_7_landsat-tvi-false/abc")
+    url_factory.assert_awaited_once()
+    fake_set.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persistent_429_raises_after_one_regeneration(fake_manager):
+    """Se o retry após regeneração também devolve 429, propaga a exceção
+    em vez de tentar uma terceira rodada — getMapId é caro e amplificar
+    custa mais que entregar 503."""
+    from app.utils import ee_tile_fetch
+
+    url_factory = AsyncMock(return_value="https://ee.googleapis.com/.../new/{z}/{x}/{y}")
+
+    fake_get = AsyncMock(side_effect=[
+        EarthEngineRateLimitedError("rate limited", sa_name="sa-old@proj"),
+        EarthEngineRateLimitedError("rate limited again", sa_name="sa-new@proj"),
+    ])
+
+    with patch.object(ee_tile_fetch, "http_get_bytes", fake_get), \
+         patch.object(ee_tile_fetch, "adelete_meta", AsyncMock()), \
+         patch.object(ee_tile_fetch, "aset_meta", AsyncMock()), \
+         patch.object(ee_tile_fetch, "get_gee_manager", return_value=fake_manager):
+
+        with pytest.raises(EarthEngineRateLimitedError):
+            await ee_tile_fetch.fetch_tile_with_rotation(
+                cache_key="landsat_MONTH_2007_7_landsat-tvi-false/abc",
+                cached_url="https://ee.googleapis.com/.../old/{z}/{x}/{y}",
+                url_factory=url_factory,
+                x=1, y=2, z=10,
+                layer="landsat",
+            )
+
+    assert fake_get.await_count == 2
+    fake_manager.rotate_on_429.assert_called_once()  # rotação única
+
+
+@pytest.mark.asyncio
+async def test_url_factory_failure_propagates(fake_manager):
+    """Se url_factory falha durante regeneração, propaga limpo — sem deixar
+    cache em estado inconsistente. delete_meta já foi chamado, mas isso é
+    aceitável (idempotente; próximo request regenera)."""
+    from app.utils import ee_tile_fetch
+
+    factory_exc = RuntimeError("getMapId failed: project quota exhausted")
+    url_factory = AsyncMock(side_effect=factory_exc)
+
+    fake_get = AsyncMock(side_effect=EarthEngineRateLimitedError("rate limited"))
+
+    with patch.object(ee_tile_fetch, "http_get_bytes", fake_get), \
+         patch.object(ee_tile_fetch, "adelete_meta", AsyncMock()), \
+         patch.object(ee_tile_fetch, "aset_meta", AsyncMock()), \
+         patch.object(ee_tile_fetch, "get_gee_manager", return_value=fake_manager):
+
+        with pytest.raises(RuntimeError, match="getMapId failed"):
+            await ee_tile_fetch.fetch_tile_with_rotation(
+                cache_key="landsat_MONTH_2007_7/abc",
+                cached_url="https://ee.googleapis.com/.../old/{z}/{x}/{y}",
+                url_factory=url_factory,
+                x=1, y=2, z=10,
+                layer="landsat",
+            )
+```
+
+- [ ] **Step 2: Rodar e confirmar falha**
+
+```bash
+pytest tests/unit/test_ee_tile_fetch.py -v
+```
+
+Esperado: `ImportError: No module named 'app.utils.ee_tile_fetch'`.
+
+- [ ] **Step 3: Implementar o helper**
+
+Arquivo: `app/utils/ee_tile_fetch.py`
+
+```python
+"""Helper de busca de tile do Earth Engine com rotação reativa de SA.
+
+Resolve o caso onde a URL cacheada está vinculada a uma SA penalizada por
+429: a rotação isolada do worker não basta, porque o token na URL continua
+preso à SA antiga. Este helper orquestra o ciclo completo:
+
+1. Tenta o download com a URL cacheada.
+2. Em EarthEngineRateLimitedError:
+   a. Rotaciona a SA do worker (acquire SA diferente, libera a antiga).
+   b. Invalida o meta-cache da URL (delete_meta).
+   c. Chama o `url_factory()` do caller para regenerar a URL via getMapId
+      com a nova SA.
+   d. Persiste a nova URL no meta-cache (set_meta).
+   e. Tenta o download **uma única vez** com a nova URL.
+3. Segundo 429 → propaga `EarthEngineRateLimitedError` para o caller
+   converter em 503. Não tentamos terceira rodada porque getMapId custa
+   ~200–500ms e amplificar custa mais que entregar erro rápido.
+
+Idempotência: o ciclo é seguro em concorrência. Múltiplos workers podem
+invalidar a mesma chave; `delete_meta` é no-op em chave ausente. Múltiplas
+regenerações simultâneas geram URLs equivalentes — set_meta da última
+prevalece, sem perda funcional.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Awaitable, Callable
+
+from app.cache.cache import adelete_meta, aset_meta
+from app.core.config import logger
+from app.core.gee_auth import get_gee_manager
+from app.utils.http import EarthEngineRateLimitedError, http_get_bytes
+
+
+async def fetch_tile_with_rotation(
+    *,
+    cache_key: str,
+    cached_url: str,
+    url_factory: Callable[[], Awaitable[str]],
+    x: int,
+    y: int,
+    z: int,
+    layer: str,
+) -> bytes:
+    """Faz download do tile, com rotação reativa em caso de 429.
+
+    Args:
+        cache_key: Chave do meta-cache da URL (ex: "landsat_MONTH_2007_7_..."/<geohash>).
+        cached_url: URL template com placeholders {x}/{y}/{z}, lida do cache.
+        url_factory: Async callable que regenera a URL via getMapId. Deve
+            ser idempotente do ponto de vista do caller (encapsula geom/dates/vis).
+        x, y, z: Coordenadas do tile.
+        layer: Nome da camada (usado em métricas e logs).
+
+    Returns:
+        Bytes do PNG do tile.
+
+    Raises:
+        EarthEngineRateLimitedError: 429 persistente após uma rotação.
+        Qualquer outra exceção do `url_factory` ou de `http_get_bytes`.
+    """
+    try:
+        return await http_get_bytes(cached_url.format(x=x, y=y, z=z))
+    except EarthEngineRateLimitedError as exc:
+        sa_old = exc.sa_name or "<unknown>"
+        logger.warning(
+            f"sa_rotated_http_429 layer={layer} cache_key={cache_key} "
+            f"sa_from={sa_old} reason=tile_429"
+        )
+
+        manager = get_gee_manager()
+        if manager is not None:
+            # rotate_on_429 é síncrono (segura init_lock + ee.Initialize).
+            await asyncio.get_event_loop().run_in_executor(None, manager.rotate_on_429)
+
+        # Invalidar a URL cacheada — assinada com a SA antiga.
+        try:
+            await adelete_meta(cache_key)
+        except Exception as del_exc:
+            logger.warning(f"Falha ao invalidar meta cache {cache_key}: {del_exc}")
+
+        # Regenerar a URL com a SA nova (via getMapId no url_factory).
+        new_url = await url_factory()
+
+        # Persistir a nova URL para próximos requests.
+        try:
+            await aset_meta(cache_key, {"url": new_url, "date": datetime.now().isoformat()})
+        except Exception as set_exc:
+            logger.warning(f"Falha ao persistir meta cache {cache_key}: {set_exc}")
+
+        # Métrica: regeneração disparada por 429.
+        try:
+            from app.core.metrics import gee_tile_url_regen_total
+            gee_tile_url_regen_total.labels(layer=layer).inc()
+        except Exception:
+            pass
+
+        # Retry único — segundo 429 propaga para o caller.
+        return await http_get_bytes(new_url.format(x=x, y=y, z=z))
+```
+
+- [ ] **Step 4: Rodar testes e confirmar que passam**
+
+```bash
+pytest tests/unit/test_ee_tile_fetch.py -v
+```
+
+Esperado: `4 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/utils/ee_tile_fetch.py tests/unit/test_ee_tile_fetch.py
+git commit -m "feat(tiles): helper fetch_tile_with_rotation com rotação reativa em 429 [#5]"
+```
+
+---
+
+## Task 5: Adotar helper em `app/api/layers.py`
+
+**Files:**
+- Modify: `app/api/layers.py:570-583` (apenas o trecho `# 4 ▸ Faz download do tile remoto`)
+
+- [ ] **Step 1: Ler o trecho atual**
+
+Verificar que `app/api/layers.py:570-583` corresponde ao código abaixo:
+
+```python
+        else:
+            layer_url = meta["url"]
+
+        # 4 ▸ Faz download do tile remoto
+        try:
+            png_bytes = await _http_get_bytes(layer_url.format(x=x, y=y, z=z))
+            logger.info(f"Tile downloaded: {file_cache} ({len(png_bytes)} bytes), saving to cache...")
+            await set_png(file_cache, png_bytes)
+            logger.info(f"Tile cached: {file_cache}")
+            return StreamingResponse(io.BytesIO(png_bytes), media_type="image/png")
+        except HTTPException as exc:
+            logger.exception("Erro ao baixar tile")
+            return tile_error_response.from_exception(exc)
+```
+
+Comando:
+```bash
+sed -n '570,584p' /home/tharles/projects_lapig/tiles/app/api/layers.py
+```
+
+- [ ] **Step 2: Adicionar import do helper**
+
+Editar `app/api/layers.py`. Após a linha `from app.utils.http import http_get_bytes as _http_get_bytes` (linha 35), adicionar:
+
+```python
+from app.utils.ee_tile_fetch import fetch_tile_with_rotation
+from app.utils.http import EarthEngineRateLimitedError
+```
+
+- [ ] **Step 3: Construir `url_factory` e usar `fetch_tile_with_rotation`**
+
+Substituir o bloco do passo 1 (linhas 570–583) por:
+
+```python
+        else:
+            layer_url = meta["url"]
+
+        # 4 ▸ Faz download do tile remoto via helper com rotação reativa.
+        #     Em 429, o helper: rotaciona SA → invalida meta cache →
+        #     regenera URL via url_factory → tenta uma vez mais.
+        async def _regenerate_url() -> str:
+            geom = ee.Geometry.BBox(bbox["w"], bbox["s"], bbox["e"], bbox["n"])
+            loop = asyncio.get_event_loop()
+            if layer == "landsat":
+                _year = datetime.fromisoformat(dates["dtStart"]).year
+                collection = get_landsat_collection(_year)
+                landsat_vis = await get_landsat_vis_params_async(visparam, collection)
+                return await loop.run_in_executor(
+                    ee_executor,
+                    _create_landsat_layer_with_params,
+                    geom, dates, landsat_vis, composite_mode or "BEST_IMAGE",
+                )
+            return await loop.run_in_executor(
+                ee_executor, builder_sync, geom, dates, vis,
+            )
+
+        try:
+            png_bytes = await fetch_tile_with_rotation(
+                cache_key=path_cache,
+                cached_url=layer_url,
+                url_factory=_regenerate_url,
+                x=x, y=y, z=z,
+                layer=layer,
+            )
+            logger.info(f"Tile downloaded: {file_cache} ({len(png_bytes)} bytes), saving to cache...")
+            await set_png(file_cache, png_bytes)
+            logger.info(f"Tile cached: {file_cache}")
+            return StreamingResponse(io.BytesIO(png_bytes), media_type="image/png")
+        except EarthEngineRateLimitedError as exc:
+            logger.warning(f"Tile 503 ee_rate_limit (após rotação): {exc}")
+            return tile_error_response(status_code=503, reason="ee_unavailable")
+        except HTTPException as exc:
+            logger.exception("Erro ao baixar tile")
+            return tile_error_response.from_exception(exc)
+```
+
+- [ ] **Step 4: Rodar a suite completa de tests**
+
+```bash
+pytest tests/unit/ -v
+```
+
+Esperado: todos os testes passam (ou pelo menos os que existiam antes + os novos desta entrega).
+
+- [ ] **Step 5: Rodar testes de integração relevantes**
+
+```bash
+pytest tests/integration/test_tile_handlers_propagate_status.py -v
+```
+
+Esperado: todos passam (o caminho 503 continua devolvendo 503 com reason `ee_unavailable`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/layers.py
+git commit -m "feat(tiles): layers.py adota fetch_tile_with_rotation [#5]"
+```
+
+---
+
+## Task 6: Adotar helper em `app/api/imagery.py`
+
+**Files:**
+- Modify: `app/api/imagery.py:455-475` (trecho do tile)
+
+- [ ] **Step 1: Ler o trecho atual**
+
+```bash
+sed -n '445,480p' /home/tharles/projects_lapig/tiles/app/api/imagery.py
+```
+
+Identificar a linha 464: `png_bytes = await http_get_bytes(layer_url.format(x=x, y=y, z=z))`. Inspecionar o contexto (variáveis em escopo, builder do tile, cache key).
+
+- [ ] **Step 2: Adicionar imports**
+
+Editar `app/api/imagery.py`. Após `from app.utils.http import http_get_bytes` (linha 32), adicionar:
+
+```python
+from app.utils.ee_tile_fetch import fetch_tile_with_rotation
+from app.utils.http import EarthEngineRateLimitedError
+```
+
+- [ ] **Step 3: Substituir o site de download pelo helper**
+
+Localizar o bloco da linha 462–475 de `app/api/imagery.py`:
+
+```python
+        # 4 ▸ Download do tile remoto
+        try:
+            png_bytes = await http_get_bytes(layer_url.format(x=x, y=y, z=z))
+            await set_png(tile_key, png_bytes)
+            return StreamingResponse(
+                io.BytesIO(png_bytes),
+                media_type="image/png",
+                headers={"X-Cache": "MISS", "X-Image-Id": imageId},
+            )
+        except HTTPException as exc:
+            logger.exception(f"Erro ao baixar tile da imagem {imageId}")
+            resp = tile_error_response.from_exception(exc)
+            resp.headers["X-Image-Id"] = imageId
+            return resp
+```
+
+Substituir por:
+
+```python
+        # 4 ▸ Download do tile remoto via helper com rotação reativa.
+        async def _regenerate_url() -> str:
+            loop = asyncio.get_event_loop()
+            if layer == "s2_harmonized":
+                vis = await _vis_param_for_s2(visparam)
+                return await loop.run_in_executor(
+                    ee_executor, _create_s2_image_layer_sync, imageId, vis,
+                )
+            vis = await _vis_param_for_landsat(visparam, imageId)
+            return await loop.run_in_executor(
+                ee_executor, _create_landsat_image_layer_sync, imageId, vis,
+            )
+
+        try:
+            png_bytes = await fetch_tile_with_rotation(
+                cache_key=meta_key,
+                cached_url=layer_url,
+                url_factory=_regenerate_url,
+                x=x, y=y, z=z,
+                layer="imagery",
+            )
+            await set_png(tile_key, png_bytes)
+            return StreamingResponse(
+                io.BytesIO(png_bytes),
+                media_type="image/png",
+                headers={"X-Cache": "MISS", "X-Image-Id": imageId},
+            )
+        except EarthEngineRateLimitedError as exc:
+            logger.warning(f"Tile imagery 503 ee_rate_limit (após rotação): {exc}")
+            resp = tile_error_response(status_code=503, reason="ee_unavailable")
+            resp.headers["X-Image-Id"] = imageId
+            return resp
+        except HTTPException as exc:
+            logger.exception(f"Erro ao baixar tile da imagem {imageId}")
+            resp = tile_error_response.from_exception(exc)
+            resp.headers["X-Image-Id"] = imageId
+            return resp
+```
+
+Variáveis em escopo já existentes neste handler (vindas de `image_tile` na linha 391):
+- `layer`, `imageId`, `visparam`, `meta_key`, `tile_key`, `layer_url`, `_create_s2_image_layer_sync`, `_create_landsat_image_layer_sync`, `_vis_param_for_s2`, `_vis_param_for_landsat`, `ee_executor`, `asyncio`.
+
+- [ ] **Step 4: Rodar testes**
+
+```bash
+pytest tests/unit/ tests/integration/test_tile_handlers_propagate_status.py -v
+```
+
+Esperado: todos os testes passam.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/imagery.py
+git commit -m "feat(tiles): imagery.py adota fetch_tile_with_rotation [#5]"
+```
+
+---
+
+## Task 7: Adotar helper em `app/modules/embedding_maps/router.py`
+
+**Files:**
+- Modify: `app/modules/embedding_maps/router.py:320-340`
+
+- [ ] **Step 1: Ler o trecho atual**
+
+```bash
+sed -n '300,340p' /home/tharles/projects_lapig/tiles/app/modules/embedding_maps/router.py
+```
+
+Identificar:
+- Linha 320: `await set_meta(meta_key, {"url": layer_url, "date": ...}, META_TTL)` — última geração da URL.
+- Linha 330: `png_bytes = await _http_get_bytes(layer_url.format(x=x, y=y, z=z))` — download alvo.
+
+- [ ] **Step 2: Adicionar imports**
+
+Após `from app.utils.http import http_get_bytes as _http_get_bytes` (linha 28), adicionar:
+
+```python
+from app.utils.ee_tile_fetch import fetch_tile_with_rotation
+from app.utils.http import EarthEngineRateLimitedError
+```
+
+- [ ] **Step 3: Extrair builder em função nomeada e adotar o helper**
+
+O builder atual é uma closure `_build_and_get_url` definida apenas no branch de URL expirada (linha 297). Para reutilizá-la no `url_factory`, mover sua definição para fora do `if expired:` — assim ambos os caminhos (geração inicial e regeneração) usam a mesma função.
+
+**3a.** Promover `_build_and_get_url` para antes do `if expired:`. Localizar o bloco da linha 280–326:
+
+```python
+        if expired:
+            config = job.get("config", {})
+            roi_config = config.get("roi", {})
+            year = config.get("year", 2023)
+            processing = config.get("processing", {})
+            scale = processing.get("scale", 10)
+
+            # Encontrar config do produto especifico
+            product_cfg = {}
+            for p in config.get("products", []):
+                if p.get("product") == product:
+                    product_cfg = p
+                    break
+
+            try:
+                loop = asyncio.get_event_loop()
+
+                def _build_and_get_url():
+                    from .schemas import RoiConfig
+                    roi = RoiConfig(**roi_config)
+                    ee_roi = roi_to_ee_geometry(roi)
+                    img = build_product_image(
+                        year, ee_roi, product,
+                        rgb_bands=product_cfg.get("rgb_bands"),
+                        pca_components=product_cfg.get("pca_components", 3),
+                        kmeans_k=product_cfg.get("kmeans_k", 8),
+                        scale=scale,
+                        sample_size=processing.get("sample_size", 5000),
+                        year_b=product_cfg.get("year_b"),
+                    )
+                    vis = build_vis_params(
+                        product,
+                        palette=product_cfg.get("palette"),
+                        vis_min=product_cfg.get("vis_min", -0.3),
+                        vis_max=product_cfg.get("vis_max", 0.3),
+                        kmeans_k=product_cfg.get("kmeans_k", 8),
+                    )
+                    return get_map_id_from_image(img, vis)
+
+                layer_url = await loop.run_in_executor(ee_executor, _build_and_get_url)
+                await set_meta(meta_key, {"url": layer_url, "date": datetime.now().isoformat()}, META_TTL)
+            except Exception:
+                logger.exception(f"Erro ao criar layer EE para job {job_id}, produto {product}")
+                error_img = generate_error_image("Erro ao gerar tile")
+                return StreamingResponse(error_img, media_type="image/png")
+        else:
+            layer_url = meta["url"]
+```
+
+Substituir por:
+
+```python
+        # Extrair config do produto antes do branch — usado tanto na geração
+        # inicial quanto na regeneração por 429.
+        config = job.get("config", {})
+        roi_config = config.get("roi", {})
+        year = config.get("year", 2023)
+        processing = config.get("processing", {})
+        scale = processing.get("scale", 10)
+
+        product_cfg = {}
+        for p in config.get("products", []):
+            if p.get("product") == product:
+                product_cfg = p
+                break
+
+        def _build_and_get_url():
+            from .schemas import RoiConfig
+            roi = RoiConfig(**roi_config)
+            ee_roi = roi_to_ee_geometry(roi)
+            img = build_product_image(
+                year, ee_roi, product,
+                rgb_bands=product_cfg.get("rgb_bands"),
+                pca_components=product_cfg.get("pca_components", 3),
+                kmeans_k=product_cfg.get("kmeans_k", 8),
+                scale=scale,
+                sample_size=processing.get("sample_size", 5000),
+                year_b=product_cfg.get("year_b"),
+            )
+            vis = build_vis_params(
+                product,
+                palette=product_cfg.get("palette"),
+                vis_min=product_cfg.get("vis_min", -0.3),
+                vis_max=product_cfg.get("vis_max", 0.3),
+                kmeans_k=product_cfg.get("kmeans_k", 8),
+            )
+            return get_map_id_from_image(img, vis)
+
+        if expired:
+            try:
+                loop = asyncio.get_event_loop()
+                layer_url = await loop.run_in_executor(ee_executor, _build_and_get_url)
+                await set_meta(meta_key, {"url": layer_url, "date": datetime.now().isoformat()}, META_TTL)
+            except Exception:
+                logger.exception(f"Erro ao criar layer EE para job {job_id}, produto {product}")
+                error_img = generate_error_image("Erro ao gerar tile")
+                return StreamingResponse(error_img, media_type="image/png")
+        else:
+            layer_url = meta["url"]
+```
+
+**3b.** Substituir o bloco do download (linha 328–339):
+
+Trecho original:
+```python
+        # 4. Download tile remoto
+        try:
+            png_bytes = await _http_get_bytes(layer_url.format(x=x, y=y, z=z))
+            await set_png(cache_key, png_bytes, PNG_TTL)
+            elapsed = (time.monotonic() - t0) * 1000
+            return StreamingResponse(
+                io.BytesIO(png_bytes),
+                media_type="image/png",
+                headers={"X-Cache-Status": "MISS", "X-Response-Time": f"{elapsed:.0f}ms"},
+            )
+        except HTTPException:
+            logger.exception(f"Erro ao baixar tile para job {job_id}")
+```
+
+Substituir por:
+```python
+        # 4. Download tile remoto via helper com rotação reativa.
+        async def _regenerate_url() -> str:
+            loop = asyncio.get_event_loop()
+            return await loop.run_in_executor(ee_executor, _build_and_get_url)
+
+        try:
+            png_bytes = await fetch_tile_with_rotation(
+                cache_key=meta_key,
+                cached_url=layer_url,
+                url_factory=_regenerate_url,
+                x=x, y=y, z=z,
+                layer="embedding_maps",
+            )
+            await set_png(cache_key, png_bytes, PNG_TTL)
+            elapsed = (time.monotonic() - t0) * 1000
+            return StreamingResponse(
+                io.BytesIO(png_bytes),
+                media_type="image/png",
+                headers={"X-Cache-Status": "MISS", "X-Response-Time": f"{elapsed:.0f}ms"},
+            )
+        except EarthEngineRateLimitedError:
+            logger.warning(f"Tile embedding_maps 503 ee_rate_limit (após rotação) job={job_id}")
+            error_img = generate_error_image("EE rate limited")
+            return StreamingResponse(error_img, media_type="image/png", status_code=503)
+        except HTTPException:
+            logger.exception(f"Erro ao baixar tile para job {job_id}")
+```
+
+Manter o restante do `except HTTPException` intacto a partir da linha 340 (não tocar no bloco de retorno do erro existente).
+
+- [ ] **Step 4: Rodar testes**
+
+```bash
+pytest tests/unit/ -v
+```
+
+Esperado: todos passam.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/modules/embedding_maps/router.py
+git commit -m "feat(tiles): embedding_maps adota fetch_tile_with_rotation [#5]"
+```
+
+---
+
+## Task 8: Documentação operacional no runbook
+
+**Files:**
+- Modify: `docs/deploy-runbook.md`
+
+- [ ] **Step 1: Ler runbook atual**
+
+```bash
+sed -n '1,50p' /home/tharles/projects_lapig/tiles/docs/deploy-runbook.md
+```
+
+- [ ] **Step 2: Adicionar seção sobre expansão do pool de SAs**
+
+Anexar ao final do `docs/deploy-runbook.md` (após a seção existente de canário/circuit breaker):
+
+```markdown
+## Expansão do pool de Service Accounts do GEE
+
+A taxa de 503 (`ee_unavailable`) sob carga é limitada pela cota das SAs
+ativas no pool, não pelo código. O fix de rotação reativa (entrega de
+2026-05-12) mitiga picos transitórios; o teto sustentável depende do
+número de SAs com cota disponível.
+
+### Sintomas que indicam saturação de capacidade
+
+- Métrica `gee_sa_rotation_total` cresce continuamente, sem estabilizar.
+- Métrica `gee_sa_in_cooldown` mostra todas as SAs alternando em cooldown.
+- `gee_tile_url_regen_total` alto e sustentado — confirma que 429 não é
+  pico transitório, é teto de capacidade.
+
+### Ação operacional
+
+1. Provisionar SAs adicionais no GCP Console (projeto `earthengine-legacy`
+   ou equivalente). Cada SA tem cota independente no endpoint de tiles.
+2. Baixar o JSON da nova SA e depositar em `.service-accounts/`:
+   ```bash
+   scp nova-sa.json prod-lapig:/path/to/.service-accounts/
+   ```
+3. Hot-reload do pool — sem necessidade de redeploy:
+   ```bash
+   curl -X POST http://localhost:8080/admin/gee-pool/refresh
+   ```
+4. Verificar que a nova SA foi descoberta:
+   ```bash
+   curl http://localhost:8080/admin/gee-pool/metrics
+   ```
+5. Acompanhar `gee_sa_http_429_total` por SA: distribuição deve ficar
+   mais equilibrada à medida que o pool absorve a carga.
+
+### Quando reduzir a frota
+
+Se `gee_sa_in_cooldown` raramente passa de 0 e `gee_sa_rotation_total`
+fica estagnado por dias seguidos, há overprovisionamento. SAs ociosas
+não custam, mas complicam a rotação dos JSONs — manter o pool em
+tamanho mínimo necessário para sustentar o pico observado.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/deploy-runbook.md
+git commit -m "docs(tiles): runbook de expansão do pool de SAs do GEE"
+```
+
+---
+
+## Task 9: Verificação final e suite completa
+
+**Files:** todas as mudanças do plano.
+
+- [ ] **Step 1: Rodar a suite inteira**
+
+```bash
+cd /home/tharles/projects_lapig/tiles
+pytest tests/ -v --tb=short
+```
+
+Esperado: 0 falhas. Se houver falha, parar, investigar e corrigir antes de seguir.
+
+- [ ] **Step 2: Verificar build do container**
+
+```bash
+docker compose -f docker-compose.yml build tile
+```
+
+Esperado: build bem-sucedido. Se falhar por import, há referência quebrada — verificar.
+
+- [ ] **Step 3: Smoke local (opcional, se há ambiente local)**
+
+```bash
+docker compose up -d valkey minio
+docker compose up tile
+```
+
+Em outro terminal:
+```bash
+curl -v "http://localhost:8080/tiles/landsat/512/512/10?year=2015&month=7" | head -c 200
+```
+
+Esperado: 200 com `Content-Type: image/png` (ou 503 com `X-Error-Reason: ee_unavailable` se EE realmente saturada; o ponto é que o serviço responde).
+
+- [ ] **Step 4: Push do branch**
+
+```bash
+git push origin <branch-name>
+```
+
+Não criar PR ou merge automático — aguardar revisão.
+
+---
+
+## Notas de execução
+
+- **Não há mudanças destrutivas no Redis** — nenhuma chave é renomeada; `delete_meta` é puramente reativo em 429.
+- **Retrocompatibilidade**: chamadas legacy a `http_get_bytes` continuam funcionando; a única diferença é que 429 persistente agora levanta `EarthEngineRateLimitedError` em vez de `HTTPException(503)`. Callers que ignoram a exceção tipada continuam servindo 503 via `tile_error_response.from_exception` (que não cobre o novo tipo) — por isso cada call site precisa do branch novo `except EarthEngineRateLimitedError`.
+- **Capacidade** continua sendo problema operacional, não de código. O plano não promete que a taxa de 503 vai a zero — promete que ela cai significativamente e fica observável.
+- **Rollback** é via `docker service rollback prod_tiles_tile` (sem migração de schema, sem mudança de contrato externo).

--- a/docs/superpowers/specs/2026-05-12-tiles-ee-429-rotation-cache-invalidation-design.md
+++ b/docs/superpowers/specs/2026-05-12-tiles-ee-429-rotation-cache-invalidation-design.md
@@ -1,0 +1,219 @@
+# Mitigação de 429 do Earth Engine em downloads de tiles
+
+**Data:** 2026-05-12
+**Serviço afetado:** `prod_tiles_tile` (FastAPI + 20 réplicas)
+**Tipo:** correção de bug + reforço arquitetural
+**Status:** rascunho para validação
+
+## 1. Contexto
+
+O serviço de tiles serve mosaicos do Google Earth Engine (Landsat, Sentinel-2, etc.) renderizando PNGs via URLs assinadas obtidas com `ee.data.getMapId`. Sob carga, uma fração significativa das respostas retorna 503 (`ee_unavailable`) e o frontend exibe placeholders aleatórios, não restritos a um período específico.
+
+Observabilidade coletada em um container, janela de cinco minutos:
+
+| Métrica | Valor |
+|---|---|
+| Requisições 200 OK | 1.468 |
+| Requisições 503 | 150 (~9,2%) |
+| Requisições 500 | 8 |
+| 429 da EE (primeira tentativa) | 252 |
+| 429 da EE (segunda tentativa) | 140 |
+| TimeoutError (10 s) | 172 |
+
+Em uma janela de trinta minutos, o pior container acumulou 28.921 erros e os demais oscilaram entre 250 e 7.343 — distribuição assimétrica entre as 20 réplicas. Os 503 distribuem-se entre os anos 1989 e 2025, sem concentração específica em 1993–2000.
+
+## 2. Diagnóstico técnico
+
+### 2.1. Causa raiz inicial (parcial)
+
+O pool de Service Accounts em `app/core/gee_pool.py` distribui SAs do GEE entre workers via Redis. Ao receber 429 em `app/utils/http.py:38` (download de tile), o código apenas registra a métrica `report_http_429`, dorme com `base_delay * 2^attempt + jitter` e retenta a mesma URL. A função `WorkerGEEManager.rotate_on_429` existe, mas só é acionada via decorador `@gee_retry` em chamadas síncronas da REST API do Earth Engine — **não** em downloads HTTP de tiles.
+
+### 2.2. Causa raiz adicional descoberta na análise
+
+A `getMapId` do EE devolve uma URL no formato:
+
+```
+https://earthengine.googleapis.com/v1/projects/earthengine-legacy/maps/{mapID}-{token}/tiles/{z}/{x}/{y}
+```
+
+O token embutido está vinculado à SA que assinou a chamada. Em `app/api/layers.py:537`, essa URL é cacheada em Redis (`set_meta(path_cache, {"url": layer_url, "date": ...})`) e reutilizada por todos os workers que servirem tiles do mesmo bbox + camada + período até o TTL expirar (`settings.LIFESPAN_URL`).
+
+Quando a SA satura:
+
+1. A URL em cache continua apontando para o token saturado.
+2. Qualquer worker que ler aquela URL fica acoplado à SA penalizada.
+3. Rotacionar a SA do worker **sem invalidar a URL cacheada** não muda o destino do retry.
+4. A rotação apenas isolada (proposta original do diagnóstico) é teatral: o retry em vôo continua falhando.
+
+### 2.3. Causa raiz operacional
+
+O pool atualmente expõe apenas duas SAs descobertas (`ee-lapig-tvi5`, `ee-lapig-tvi7`) servindo 20 réplicas. Mesmo com rotação perfeita, duas SAs saturando produzem oscilação A → B → A → B sob carga real. O fix de código mitiga picos transitórios; o teto sustentável é capacidade de cota — exige expansão de SAs no pool.
+
+### 2.4. Contribuição do timeout
+
+`ClientTimeout(total=10.0)` esgota o budget quando o EE responde em 8–12 s sob carga. Os 172 TimeoutErrors observados em cinco minutos refletem esse aperto. O retry com backoff dorme entre 1 e 4 s entre tentativas, comendo ainda mais do orçamento.
+
+## 3. Objetivos e não-objetivos
+
+### Objetivos
+
+- Eliminar a parcela dos 503 cuja causa é rotação ausente em 429 de download de tile.
+- Reduzir TimeoutErrors em condição de EE lento mas saudável.
+- Tornar o cache de URL responsivo a 429 (invalidar e regenerar com SA fresca).
+- Adicionar observabilidade granular por SA para diagnóstico futuro.
+
+### Não-objetivos
+
+- Não alterar o circuit breaker recém-introduzido (PR #5).
+- Não introduzir CDN ou cache de borda nesta iteração.
+- Não modificar o caminho da REST API (`app/utils/ee_compute.py`) — já contém rotação reativa em 429 desde a iteração anterior.
+- Não tocar no frontend `tiles-client`.
+- Não otimizar custo/quota da conta GCP — escopo operacional, fora deste design.
+
+## 4. Estratégia técnica
+
+A solução tem cinco componentes, ordenados por dependência.
+
+### C1 — Exceção tipada em `http_get_bytes`
+
+Substituir `HTTPException(503, …)` lançada na rota de 429 por uma exceção dedicada `EarthEngineRateLimitedError(message, sa_name)`. O caller passa a poder reagir especificamente a 429 versus erros HTTP genéricos.
+
+`http_get_bytes` permanece agnóstico de GEE — não chama `mgr.rotate_on_429`, não toca em Redis de cache de URL. A única dependência GEE que mantém é o registro de métrica via `mgr.report_http_429()`, que é fire-and-forget.
+
+Justificativa da separação: `http_get_bytes` é usada por três módulos distintos (`layers.py`, `imagery.py`, `embedding_maps/router.py`). Cada um tem sua estratégia de geração de URL. Acoplar `http_get_bytes` ao domínio GEE quebraria a generalidade.
+
+### C2 — Helper `fetch_tile_with_rotation` em `app/utils/ee_tile_fetch.py`
+
+Novo módulo. Função:
+
+```python
+async def fetch_tile_with_rotation(
+    cache_key: str,
+    url_factory: Callable[[], Awaitable[str]],
+    x: int, y: int, z: int,
+) -> bytes:
+    """
+    1. Lê URL do meta cache (chave cache_key).
+    2. Tenta http_get_bytes(url.format(x, y, z)).
+    3. Em EarthEngineRateLimitedError:
+       a. mgr.rotate_on_429() — abandona SA atual, adquire nova.
+       b. Invalida meta cache (delete_meta(cache_key)).
+       c. Chama url_factory() para regenerar URL com nova SA.
+       d. Persiste nova URL em meta cache.
+       e. Retenta http_get_bytes uma única vez.
+    4. Segundo 429 → propaga EarthEngineRateLimitedError, caller converte em 503.
+    """
+```
+
+Limite rígido de uma regeneração por request. `getMapId` custa de 200 a 500 ms por round-trip; mais que isso transforma 429 em latência cumulativa pior que o próprio erro.
+
+### C3 — Refator dos três call sites
+
+`app/api/layers.py:576`, `app/api/imagery.py:464`, `app/modules/embedding_maps/router.py:330` passam a usar `fetch_tile_with_rotation`. Cada um fornece o seu `url_factory` (encapsulando `_create_landsat_layer_with_params`, `_create_s2_layer_sync`, etc.).
+
+Sem regressão de comportamento: o caminho feliz continua idêntico (lê meta cache, baixa via `http_get_bytes`). Só o caminho de erro 429 ganha o ciclo de rotação + invalidação + regeneração.
+
+### C4 — Aumento de timeout
+
+`ClientTimeout(total=10.0)` passa para `ClientTimeout(total=20.0)`. Configurável via `settings.HTTP_GET_BYTES_TIMEOUT` (padrão 20.0). Justificativa: dar margem para a EE responder sob carga sem consumir todo o budget no primeiro retry. Risco controlado: o circuit breaker continua disparando quando os erros se acumulam, evitando worker starvation.
+
+### C5 — Observabilidade granular
+
+Já existe endpoint `/metrics` Prometheus (PR #6). Adicionar:
+
+- Em `app/core/gee_pool.py`:
+  - `gee_sa_http_429_total{sa_name}` — counter incrementado em `report_http_429`.
+  - `gee_sa_rotation_total{from_sa, to_sa, trigger}` — counter em `rotate_on_429` (`trigger=http_429|rest_api_429`).
+  - `gee_sa_in_cooldown{sa_name}` — gauge atualizado em `report_http_429` e `report_429`.
+- Em `app/utils/ee_tile_fetch.py`:
+  - `gee_tile_url_regen_total{layer}` — counter incrementado a cada regeneração de URL disparada por 429.
+
+Log estruturado em `fetch_tile_with_rotation`: campo `event=sa_rotated_http_429` com `sa_from`, `sa_to`, `request_id` (já propagado via `RequestIdMiddleware` da PR #7).
+
+### C6 — Documentação operacional (fora do código)
+
+No `docs/deploy-runbook.md`, adicionar seção curta sobre expansão do pool de SAs:
+
+- Sintoma: oscilação visível em `gee_sa_rotation_total` entre poucas SAs.
+- Ação: provisionar SAs adicionais no GCP, depositar JSON em `.service-accounts/`, chamar `POST /admin/gee-pool/refresh` (já implementado em `refresh_registry`).
+
+## 5. Estrutura de arquivos
+
+```
+app/
+├── utils/
+│   ├── http.py                  # editar: timeout, exceção tipada
+│   └── ee_tile_fetch.py         # NOVO: helper fetch_tile_with_rotation
+├── core/
+│   └── gee_pool.py              # editar: counters Prometheus por SA
+├── api/
+│   ├── layers.py                # editar: usar fetch_tile_with_rotation
+│   └── imagery.py               # editar: usar fetch_tile_with_rotation
+└── modules/
+    └── embedding_maps/
+        └── router.py            # editar: usar fetch_tile_with_rotation
+tests/
+├── utils/
+│   ├── test_http.py             # editar: testar EarthEngineRateLimitedError
+│   └── test_ee_tile_fetch.py    # NOVO
+└── core/
+    └── test_gee_pool.py         # editar: counters
+docs/
+└── deploy-runbook.md            # editar: seção expansão de SAs
+```
+
+## 6. Estratégia de testes
+
+### Unitário
+
+- `tests/utils/test_http.py`: mockar `aiohttp` retornando 429 → confirmar que `EarthEngineRateLimitedError` é lançado com `sa_name` correto.
+- `tests/utils/test_ee_tile_fetch.py`:
+  - 429 na primeira tentativa, sucesso após rotação → confirmar 1× call de `rotate_on_429`, 1× `delete_meta`, 1× `url_factory`, 1× retry de `http_get_bytes` retornando 200.
+  - 429 em ambas as tentativas → confirmar propagação de erro, sem terceira tentativa.
+  - 200 no primeiro shot → caminho feliz, sem invocar rotação ou regeneração.
+  - `url_factory` levanta exceção → confirmar que a falha é propagada limpa, sem deixar cache em estado inconsistente.
+- `tests/core/test_gee_pool.py`: incrementos de counter Prometheus após `report_http_429` e `rotate_on_429`.
+
+### Integração
+
+- Suite em `tests/integration/test_tile_rotation.py` com Redis e mock EE local (aiohttp test server) que alterna 200 / 429 por header `Authorization`. Confirmar que após 429, a próxima request usa um token diferente e devolve 200.
+
+### Carga (manual, pós-deploy canário)
+
+- Script `scripts/load_test_tiles.py` que dispara 1.000 reqs/min contra Landsat 1993–2025 random. Métricas alvo:
+  - Taxa de 503 < 1%.
+  - p95 de latência < 8 s.
+  - `gee_sa_rotation_total` cresce em picos, depois estabiliza.
+
+## 7. Riscos e mitigações
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|---|---|---|---|
+| Regeneração de URL aumenta latência média | Média | Médio | Limitar a 1 regeneração por request. Métrica `gee_tile_url_regen_total` monitora a taxa. |
+| Thundering herd em regeneração simultânea | Baixa | Médio | `layers.py:520` já usa `tile_lock(f"url:{path_cache}")` ao redor da geração inicial; `embedding_maps/router.py:261` tem padrão equivalente. Aplicar o mesmo lock dentro de `fetch_tile_with_rotation` ao redor da regeneração; `imagery.py` ganha o lock no `url_factory` ao adotar o helper. |
+| Worker rotaciona, mas cooldown da SA antiga ainda permite reaquisição por outro worker | Média | Baixo | `report_http_429` já aplica cooldown de 15 s na SA. O outro worker é bloqueado de adquiri-la durante esse período. |
+| Capacidade insuficiente persistente (somente 2 SAs) | Alta | Alto | Documentação operacional explícita (C6); métricas tornam o sintoma visível antes do incidente. |
+| Aumento de timeout deixa workers presos em requests lentas | Baixa | Médio | Circuit breaker da PR #5 corta upstream quando taxa de erro sobe; o número de workers (`gunicorn_conf.py`) tem reserva para absorver requests com timeout mais longo. |
+
+## 8. Plano de rollout
+
+1. **Implementação** em branch dedicada com testes verdes localmente.
+2. **Build** da imagem `tiles:ee-429-rotation`.
+3. **Deploy canário** em uma réplica (`docker service update --image ... --replicas 1` ou similar do runbook).
+4. **Monitoramento** por 30 min: taxa de 503, `gee_sa_rotation_total`, p95 de latência.
+5. **Rollout completo** se métricas estáveis; **rollback** via `docker service rollback` se taxa de 503 não baixar ou se p95 piorar.
+6. **Pós-deploy**: avaliar necessidade de expandir o pool de SAs com base em `gee_sa_rotation_total` e quotas GCP.
+
+## 9. Critérios de aceite
+
+- Taxa de 503 em produção cai abaixo de 2% sob carga comparável (de ~9% observados).
+- Logs evidenciam rotação de SA disparada por 429 de download HTTP (campo `event=sa_rotated_http_429`).
+- Métrica `gee_tile_url_regen_total` é não-nula sob carga, comprovando que o cache está sendo invalidado e regenerado.
+- Nenhuma regressão em testes existentes (`pytest tests/`).
+- Sem aumento mensurável de p95 de latência no caminho feliz.
+
+## 10. Trabalho derivado (fora do escopo desta entrega)
+
+- Expandir pool de SAs no GCP (tarefa operacional).
+- Avaliar adoção de CDN para PNGs com `Cache-Control` longo.
+- Reduzir o `LIFESPAN_URL` se o EE começar a invalidar tokens proativamente.

--- a/settings.toml
+++ b/settings.toml
@@ -2,6 +2,11 @@
 GEE_SERVICE_ACCOUNT_FILE='/app/.service-accounts/gee.json'
 LIFESPAN_URL = 24  # Aumentado para 24 horas
 
+# Timeout total (segundos) por tentativa de download de tile do EE.
+# 10s era insuficiente sob carga (EE responde em 8–12s); 20s reduz
+# TimeoutErrors sem prolongar excessivamente requests com EE realmente lento.
+HTTP_GET_BYTES_TIMEOUT = 20
+
 # Cache híbrido
 REDIS_URL = 'redis://valkey:6379'
 S3_ENDPOINT = 'http://minio:9000'

--- a/settings.toml
+++ b/settings.toml
@@ -36,6 +36,7 @@ USE_MONGODB_VIS_PARAMS=true  # Set to true after running migration script
 # GEE Service Account Pool
 GEE_SA_DIRECTORY = '/app/.service-accounts/'
 GEE_SA_COOLDOWN_SECONDS = 60       # Cooldown após 429 (segundos)
+GEE_SA_HTTP_COOLDOWN_SECONDS = 15  # Cooldown após 429 do download HTTP de tile (s)
 GEE_SA_MAX_RETRIES = 2             # Máximo de rotações de SA por requisição
 GEE_SA_HEARTBEAT_INTERVAL = 30     # Intervalo de heartbeat (segundos)
 GEE_SA_ASSIGNMENT_TTL = 90         # TTL do assignment no Redis (segundos)

--- a/tests/integration/test_circuit_breaker_integration.py
+++ b/tests/integration/test_circuit_breaker_integration.py
@@ -28,6 +28,7 @@ def app_with_cb(monkeypatch):
     cache_mod.aset_png = _noop
     cache_mod.aget_meta = _none
     cache_mod.aset_meta = _noop
+    cache_mod.adelete_meta = _noop
     cache_mod.atile_lock = _fake_lock
     sys.modules["app.cache.cache"] = cache_mod
 
@@ -93,7 +94,17 @@ def app_with_cb(monkeypatch):
     http_util = type(sys)("app.utils.http")
     async def _hgb(url, **k): return b""
     http_util.http_get_bytes = _hgb
+    class _EarthEngineRateLimitedError(Exception):
+        def __init__(self, message: str = "", sa_name=None):
+            super().__init__(message)
+            self.sa_name = sa_name
+    http_util.EarthEngineRateLimitedError = _EarthEngineRateLimitedError
     sys.modules["app.utils.http"] = http_util
+
+    ee_tile_fetch_mod = type(sys)("app.utils.ee_tile_fetch")
+    async def _fetch_tile(*_a, **_k): return b""
+    ee_tile_fetch_mod.fetch_tile_with_rotation = _fetch_tile
+    sys.modules["app.utils.ee_tile_fetch"] = ee_tile_fetch_mod
 
     from app.api import layers
     app = FastAPI()

--- a/tests/integration/test_landsat_validation_rejects_early.py
+++ b/tests/integration/test_landsat_validation_rejects_early.py
@@ -30,6 +30,7 @@ def app_with_layers():
     cache_mod.aset_png = _noop
     cache_mod.aget_meta = _none
     cache_mod.aset_meta = _noop
+    cache_mod.adelete_meta = _noop
     cache_mod.atile_lock = _fake_lock
     sys.modules["app.cache.cache"] = cache_mod
 
@@ -85,7 +86,17 @@ def app_with_layers():
     http_util = type(sys)("app.utils.http")
     async def _hgb(url, **k): return b""
     http_util.http_get_bytes = _hgb
+    class _EarthEngineRateLimitedError(Exception):
+        def __init__(self, message: str = "", sa_name=None):
+            super().__init__(message)
+            self.sa_name = sa_name
+    http_util.EarthEngineRateLimitedError = _EarthEngineRateLimitedError
     sys.modules["app.utils.http"] = http_util
+
+    ee_tile_fetch_mod = type(sys)("app.utils.ee_tile_fetch")
+    async def _fetch_tile(*_a, **_k): return b""
+    ee_tile_fetch_mod.fetch_tile_with_rotation = _fetch_tile
+    sys.modules["app.utils.ee_tile_fetch"] = ee_tile_fetch_mod
 
     from app.api import layers
     app = FastAPI()

--- a/tests/integration/test_tile_handlers_propagate_status.py
+++ b/tests/integration/test_tile_handlers_propagate_status.py
@@ -271,3 +271,47 @@ def test_internal_serve_tile_tile_download_failure_returns_real_status(
     assert resp.headers["retry-after"] == "30"
     assert resp.headers["x-error-reason"] == "ee_rate_limit"
     assert resp.headers["cache-control"] == "no-store, must-revalidate"
+
+
+def test_internal_serve_tile_persistent_429_returns_503_ee_unavailable(
+    app_with_layers, monkeypatch,
+):
+    """Quando fetch_tile_with_rotation lança EarthEngineRateLimitedError
+    (429 persistente após rotação), _serve_tile retorna 503 com X-Error-Reason
+    'ee_unavailable' e não 'ee_rate_limit' — após rotação, o EE está
+    efetivamente indisponível para o cliente, não apenas rate-limited.
+
+    Verifica também que breaker.record_failure() é chamado: o CB não pode ficar
+    cego a esta classe de falha (429 persistente sob carga é a mais relevante).
+    """
+    from app.api import layers
+    from unittest.mock import AsyncMock
+
+    _cb = AsyncMock()
+    _cb.is_open = AsyncMock(return_value=False)
+    _cb.record_success = AsyncMock()
+    _cb.record_failure = AsyncMock()
+    monkeypatch.setattr(layers, "get_ee_circuit_breaker", lambda: _cb)
+
+    # Cache meta válido → pula branch de criação de layer, vai direto pro download.
+    async def _valid_meta(*_a, **_k):
+        return {"url": "https://ee.example/{x}/{y}/{z}",
+                "date": "2999-01-01T00:00:00"}
+    monkeypatch.setattr(layers, "get_meta", _valid_meta)
+
+    # Simula 429 persistente: helper esgotou todos os SAs disponíveis.
+    fake_exc = layers.EarthEngineRateLimitedError("esgotado", sa_name="sa-x@proj")
+
+    async def _boom(*_a, **_k):
+        raise fake_exc
+
+    monkeypatch.setattr(layers, "fetch_tile_with_rotation", _boom)
+
+    client = TestClient(app_with_layers)
+    resp = client.get("/landsat/100/100/10?year=2020&visparam=landsat-tvi-true")
+
+    assert resp.status_code == 503
+    assert resp.headers.get("x-error-reason") == "ee_unavailable"
+    assert "no-store" in resp.headers.get("cache-control", "")
+    # CB deve ter sido notificado da falha persistente.
+    _cb.record_failure.assert_called_once()

--- a/tests/integration/test_tile_handlers_propagate_status.py
+++ b/tests/integration/test_tile_handlers_propagate_status.py
@@ -35,6 +35,7 @@ def app_with_layers():
     cache_mod.aset_png = _noop
     cache_mod.aget_meta = _none
     cache_mod.aset_meta = _noop
+    cache_mod.adelete_meta = _noop
     cache_mod.atile_lock = _fake_lock
     sys.modules["app.cache.cache"] = cache_mod
 
@@ -110,7 +111,17 @@ def app_with_layers():
     http_util = type(sys)("app.utils.http")
     async def _hgb(url, **k): return b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
     http_util.http_get_bytes = _hgb
+    class _EarthEngineRateLimitedError(Exception):
+        def __init__(self, message: str = "", sa_name=None):
+            super().__init__(message)
+            self.sa_name = sa_name
+    http_util.EarthEngineRateLimitedError = _EarthEngineRateLimitedError
     sys.modules["app.utils.http"] = http_util
+
+    ee_tile_fetch_mod = type(sys)("app.utils.ee_tile_fetch")
+    async def _fetch_tile(*_a, **_k): return b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    ee_tile_fetch_mod.fetch_tile_with_rotation = _fetch_tile
+    sys.modules["app.utils.ee_tile_fetch"] = ee_tile_fetch_mod
 
     from app.api import layers
 
@@ -249,7 +260,9 @@ def test_internal_serve_tile_tile_download_failure_returns_real_status(
 
     async def _boom(*_a, **_k):
         raise HTTPException(status_code=429, detail="rate limited")
-    monkeypatch.setattr(layers, "_http_get_bytes", _boom)
+    # layers.py agora usa fetch_tile_with_rotation; _http_get_bytes não é mais
+    # chamado no caminho de download do tile.
+    monkeypatch.setattr(layers, "fetch_tile_with_rotation", _boom)
 
     client = TestClient(app_with_layers)
     resp = client.get("/landsat/100/100/10?year=2020&visparam=landsat-tvi-true")

--- a/tests/unit/test_cache_delete_meta.py
+++ b/tests/unit/test_cache_delete_meta.py
@@ -1,0 +1,15 @@
+"""adelete_meta — invalida URL cacheada após 429 da SA. Sem isso,
+workers continuam lendo URL acoplada à SA penalizada."""
+from __future__ import annotations
+
+import pytest
+
+from app.cache import cache as cache_mod
+
+
+@pytest.mark.asyncio
+async def test_adelete_meta_is_async_callable():
+    """A função existe e é assíncrona — caller usa `await adelete_meta(...)`."""
+    import inspect
+    assert hasattr(cache_mod, "adelete_meta")
+    assert inspect.iscoroutinefunction(cache_mod.adelete_meta)

--- a/tests/unit/test_ee_tile_fetch.py
+++ b/tests/unit/test_ee_tile_fetch.py
@@ -79,7 +79,7 @@ async def test_429_triggers_full_rotation_cycle(fake_manager):
 
     assert result == b"PNG-NEW"
     assert fake_get.await_count == 2
-    fake_manager.rotate_on_429.assert_called_once()
+    fake_manager.rotate_on_429.assert_called_once_with(trigger="http_429")
     fake_del.assert_awaited_once_with("landsat_MONTH_2007_7_landsat-tvi-false/abc")
     url_factory.assert_awaited_once()
     fake_set.assert_awaited_once()

--- a/tests/unit/test_ee_tile_fetch.py
+++ b/tests/unit/test_ee_tile_fetch.py
@@ -1,0 +1,144 @@
+"""Cobre o helper que orquestra rotação de SA + invalidação de cache +
+regeneração de URL em 429 do download de tile.
+
+Caminho feliz: passthrough simples para http_get_bytes.
+Caminho de erro: 429 → rotate + delete_meta + url_factory + retry único.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.utils.http import EarthEngineRateLimitedError
+
+
+@pytest.fixture
+def fake_manager():
+    mgr = MagicMock()
+    mgr.current_sa_name = "sa-old@proj"
+    mgr.rotate_on_429 = MagicMock(
+        side_effect=lambda *_a, **_k: setattr(mgr, "current_sa_name", "sa-new@proj")
+    )
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_happy_path_no_rotation(fake_manager):
+    """200 no primeiro shot — não rotaciona, não invalida cache, não regenera."""
+    from app.utils import ee_tile_fetch
+
+    url_factory = AsyncMock()
+
+    with patch.object(ee_tile_fetch, "http_get_bytes", AsyncMock(return_value=b"PNG")) as fake_get, \
+         patch.object(ee_tile_fetch, "adelete_meta", AsyncMock()) as fake_del, \
+         patch.object(ee_tile_fetch, "aset_meta", AsyncMock()) as fake_set, \
+         patch.object(ee_tile_fetch, "get_gee_manager", return_value=fake_manager):
+
+        result = await ee_tile_fetch.fetch_tile_with_rotation(
+            cache_key="landsat_MONTH_2007_7_landsat-tvi-false/abc",
+            cached_url="https://ee.googleapis.com/.../{z}/{x}/{y}",
+            url_factory=url_factory,
+            x=1, y=2, z=10,
+            layer="landsat",
+        )
+
+    assert result == b"PNG"
+    fake_get.assert_awaited_once()
+    url_factory.assert_not_called()
+    fake_del.assert_not_called()
+    fake_set.assert_not_called()
+    fake_manager.rotate_on_429.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_429_triggers_full_rotation_cycle(fake_manager):
+    """429 na primeira chamada → rotate + delete_meta + url_factory + retry."""
+    from app.utils import ee_tile_fetch
+
+    url_factory = AsyncMock(return_value="https://ee.googleapis.com/.../new/{z}/{x}/{y}")
+
+    # Primeira chamada lança 429; segunda devolve bytes.
+    fake_get = AsyncMock(side_effect=[
+        EarthEngineRateLimitedError("rate limited", sa_name="sa-old@proj"),
+        b"PNG-NEW",
+    ])
+
+    with patch.object(ee_tile_fetch, "http_get_bytes", fake_get), \
+         patch.object(ee_tile_fetch, "adelete_meta", AsyncMock()) as fake_del, \
+         patch.object(ee_tile_fetch, "aset_meta", AsyncMock()) as fake_set, \
+         patch.object(ee_tile_fetch, "get_gee_manager", return_value=fake_manager):
+
+        result = await ee_tile_fetch.fetch_tile_with_rotation(
+            cache_key="landsat_MONTH_2007_7_landsat-tvi-false/abc",
+            cached_url="https://ee.googleapis.com/.../old/{z}/{x}/{y}",
+            url_factory=url_factory,
+            x=1, y=2, z=10,
+            layer="landsat",
+        )
+
+    assert result == b"PNG-NEW"
+    assert fake_get.await_count == 2
+    fake_manager.rotate_on_429.assert_called_once()
+    fake_del.assert_awaited_once_with("landsat_MONTH_2007_7_landsat-tvi-false/abc")
+    url_factory.assert_awaited_once()
+    fake_set.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persistent_429_raises_after_one_regeneration(fake_manager):
+    """Se o retry após regeneração também devolve 429, propaga a exceção
+    em vez de tentar uma terceira rodada — getMapId é caro e amplificar
+    custa mais que entregar 503."""
+    from app.utils import ee_tile_fetch
+
+    url_factory = AsyncMock(return_value="https://ee.googleapis.com/.../new/{z}/{x}/{y}")
+
+    fake_get = AsyncMock(side_effect=[
+        EarthEngineRateLimitedError("rate limited", sa_name="sa-old@proj"),
+        EarthEngineRateLimitedError("rate limited again", sa_name="sa-new@proj"),
+    ])
+
+    with patch.object(ee_tile_fetch, "http_get_bytes", fake_get), \
+         patch.object(ee_tile_fetch, "adelete_meta", AsyncMock()), \
+         patch.object(ee_tile_fetch, "aset_meta", AsyncMock()), \
+         patch.object(ee_tile_fetch, "get_gee_manager", return_value=fake_manager):
+
+        with pytest.raises(EarthEngineRateLimitedError):
+            await ee_tile_fetch.fetch_tile_with_rotation(
+                cache_key="landsat_MONTH_2007_7_landsat-tvi-false/abc",
+                cached_url="https://ee.googleapis.com/.../old/{z}/{x}/{y}",
+                url_factory=url_factory,
+                x=1, y=2, z=10,
+                layer="landsat",
+            )
+
+    assert fake_get.await_count == 2
+    fake_manager.rotate_on_429.assert_called_once()  # rotação única
+
+
+@pytest.mark.asyncio
+async def test_url_factory_failure_propagates(fake_manager):
+    """Se url_factory falha durante regeneração, propaga limpo — sem deixar
+    cache em estado inconsistente. delete_meta já foi chamado, mas isso é
+    aceitável (idempotente; próximo request regenera)."""
+    from app.utils import ee_tile_fetch
+
+    factory_exc = RuntimeError("getMapId failed: project quota exhausted")
+    url_factory = AsyncMock(side_effect=factory_exc)
+
+    fake_get = AsyncMock(side_effect=EarthEngineRateLimitedError("rate limited"))
+
+    with patch.object(ee_tile_fetch, "http_get_bytes", fake_get), \
+         patch.object(ee_tile_fetch, "adelete_meta", AsyncMock()), \
+         patch.object(ee_tile_fetch, "aset_meta", AsyncMock()), \
+         patch.object(ee_tile_fetch, "get_gee_manager", return_value=fake_manager):
+
+        with pytest.raises(RuntimeError, match="getMapId failed"):
+            await ee_tile_fetch.fetch_tile_with_rotation(
+                cache_key="landsat_MONTH_2007_7/abc",
+                cached_url="https://ee.googleapis.com/.../old/{z}/{x}/{y}",
+                url_factory=url_factory,
+                x=1, y=2, z=10,
+                layer="landsat",
+            )

--- a/tests/unit/test_gee_pool_metrics.py
+++ b/tests/unit/test_gee_pool_metrics.py
@@ -1,0 +1,45 @@
+"""Counters Prometheus por SA são essenciais para diagnosticar oscilação
+entre SAs e capacidade de cota — sintoma escondido sem essa observabilidade."""
+from __future__ import annotations
+
+from prometheus_client import REGISTRY
+
+
+def _read_counter(name: str, **labels: str) -> float:
+    """Lê o valor atual de um counter Prometheus com os labels dados."""
+    value = REGISTRY.get_sample_value(name, labels=labels)
+    return value if value is not None else 0.0
+
+
+def test_gee_sa_http_429_total_counter_exists():
+    """gee_sa_http_429_total — contador por SA penalizada por 429 de tile."""
+    from app.core import metrics  # noqa: F401
+    val = _read_counter("gee_sa_http_429_total", sa_name="probe-sa@proj")
+    assert val == 0.0  # counter inicia em 0
+
+
+def test_gee_sa_rotation_total_counter_exists():
+    """gee_sa_rotation_total — contador de rotações por origem/destino/trigger."""
+    from app.core import metrics  # noqa: F401
+    val = _read_counter(
+        "gee_sa_rotation_total",
+        from_sa="probe-from",
+        to_sa="probe-to",
+        trigger="http_429",
+    )
+    assert val == 0.0
+
+
+def test_gee_sa_in_cooldown_gauge_exists():
+    """gee_sa_in_cooldown — gauge 0/1 por SA, útil para alerta de capacidade."""
+    from app.core import metrics  # noqa: F401
+    val = REGISTRY.get_sample_value(
+        "gee_sa_in_cooldown", labels={"sa_name": "probe-sa@proj"}
+    )
+    # Gauge não inicializado retorna None; teste só valida que o nome existe
+    # via uma chamada subsequente.
+    metrics.gee_sa_in_cooldown.labels(sa_name="probe-sa@proj").set(0)
+    val = REGISTRY.get_sample_value(
+        "gee_sa_in_cooldown", labels={"sa_name": "probe-sa@proj"}
+    )
+    assert val == 0.0

--- a/tests/unit/test_http_retries_reduced.py
+++ b/tests/unit/test_http_retries_reduced.py
@@ -24,6 +24,14 @@ def test_timeout_parameter_present():
 
 def test_default_timeout_resolves_to_twenty_seconds():
     """Default é resolvido em runtime via settings.HTTP_GET_BYTES_TIMEOUT;
-    a constante esperada é 20 s — margem para EE responder em 8–12 s sob carga."""
+    a constante esperada é 20 s — margem para EE responder em 8–12 s sob carga.
+
+    Verifica que a chave existe no settings (não apenas que o fallback bate).
+    Se HTTP_GET_BYTES_TIMEOUT for removido do settings.toml por engano,
+    este teste deve falhar."""
     from app.core.config import settings
-    assert settings.get("HTTP_GET_BYTES_TIMEOUT", 20.0) == 20
+    # Sentinela único: detecta a ausência da chave (sem confundir com o default 20.0).
+    _MISSING = object()
+    value = settings.get("HTTP_GET_BYTES_TIMEOUT", _MISSING)
+    assert value is not _MISSING, "HTTP_GET_BYTES_TIMEOUT deve estar definida em settings.toml"
+    assert value == 20

--- a/tests/unit/test_http_retries_reduced.py
+++ b/tests/unit/test_http_retries_reduced.py
@@ -1,5 +1,7 @@
 """PR #5: retries default de `http_get_bytes` foi reduzido de 5 para 3 e
-timeout explícito foi adicionado à sessão aiohttp."""
+timeout explícito foi adicionado à sessão aiohttp. A partir do fix de 429
+de 2026-05-12, o timeout default é resolvido via `settings.HTTP_GET_BYTES_TIMEOUT`
+(20 s)."""
 from __future__ import annotations
 
 import inspect
@@ -14,12 +16,14 @@ def test_default_max_retries_is_three():
     assert sig.parameters["max_retries"].default == 3
 
 
-def test_explicit_timeout_parameter_present():
-    """Sem timeout, worker pode ficar pendurado em EE lento indefinidamente —
-    esgota o thread pool e trava o serviço."""
+def test_timeout_parameter_present():
+    """Sem timeout, worker fica pendurado em EE lento — esgota o thread pool."""
     sig = inspect.signature(http_mod.http_get_bytes)
     assert "timeout" in sig.parameters
-    default_timeout = sig.parameters["timeout"].default
-    # Deve ser finito e "agressivo" — 10s é o limite prático para um tile.
-    assert default_timeout is not None
-    assert 5 <= default_timeout <= 15
+
+
+def test_default_timeout_resolves_to_twenty_seconds():
+    """Default é resolvido em runtime via settings.HTTP_GET_BYTES_TIMEOUT;
+    a constante esperada é 20 s — margem para EE responder em 8–12 s sob carga."""
+    from app.core.config import settings
+    assert settings.get("HTTP_GET_BYTES_TIMEOUT", 20.0) == 20

--- a/tests/unit/test_http_typed_exception.py
+++ b/tests/unit/test_http_typed_exception.py
@@ -1,0 +1,51 @@
+"""http_get_bytes deve lançar EarthEngineRateLimitedError ao esgotar retries
+em 429 — permite que o caller diferencie 429 (recuperável via rotação) de
+falhas HTTP genéricas (irrecuperáveis)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.utils import http as http_mod
+from app.utils.http import EarthEngineRateLimitedError, http_get_bytes
+
+
+def _fake_aiohttp_session(status: int):
+    """Constrói um ClientSession fake cujo .get(...) devolve um response
+    com o status pedido. Suporta o padrão `async with session.get(...) as r`."""
+    resp = MagicMock()
+    resp.status = status
+    resp.read = AsyncMock(return_value=b"")
+    resp.reason = "Too Many Requests"
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=None)
+
+    sess = MagicMock()
+    sess.get = MagicMock(return_value=resp)
+    sess.__aenter__ = AsyncMock(return_value=sess)
+    sess.__aexit__ = AsyncMock(return_value=None)
+    return sess
+
+
+@pytest.mark.asyncio
+async def test_exception_class_exists_and_carries_sa_name():
+    """EarthEngineRateLimitedError é exportada e aceita sa_name opcional."""
+    exc = EarthEngineRateLimitedError("rate limited", sa_name="sa-x@proj")
+    assert isinstance(exc, Exception)
+    assert exc.sa_name == "sa-x@proj"
+
+
+@pytest.mark.asyncio
+async def test_persistent_429_raises_typed_exception():
+    """Após esgotar todas as tentativas com 429, deve subir
+    EarthEngineRateLimitedError — não HTTPException."""
+    fake = _fake_aiohttp_session(status=429)
+
+    with patch("app.utils.http.aiohttp.ClientSession", return_value=fake):
+        with pytest.raises(EarthEngineRateLimitedError):
+            await http_get_bytes(
+                "http://example.com/tile.png",
+                max_retries=2,
+                base_delay=0.0,
+            )

--- a/tests/unit/test_http_typed_exception.py
+++ b/tests/unit/test_http_typed_exception.py
@@ -39,13 +39,16 @@ async def test_exception_class_exists_and_carries_sa_name():
 @pytest.mark.asyncio
 async def test_persistent_429_raises_typed_exception():
     """Após esgotar todas as tentativas com 429, deve subir
-    EarthEngineRateLimitedError — não HTTPException."""
+    EarthEngineRateLimitedError — não HTTPException. No ambiente de teste
+    não há gee_manager inicializado, então sa_name deve ser None."""
     fake = _fake_aiohttp_session(status=429)
 
     with patch("app.utils.http.aiohttp.ClientSession", return_value=fake):
-        with pytest.raises(EarthEngineRateLimitedError):
+        with pytest.raises(EarthEngineRateLimitedError) as exc_info:
             await http_get_bytes(
                 "http://example.com/tile.png",
                 max_retries=2,
                 base_delay=0.0,
             )
+
+    assert exc_info.value.sa_name is None

--- a/tests/unit/test_landsat_band_fallback.py
+++ b/tests/unit/test_landsat_band_fallback.py
@@ -33,6 +33,7 @@ def layers_module():
     cache_mod.aset_png = _noop
     cache_mod.aget_meta = _none
     cache_mod.aset_meta = _noop
+    cache_mod.adelete_meta = _noop
     cache_mod.atile_lock = _fake_lock
     sys.modules["app.cache.cache"] = cache_mod
 
@@ -88,7 +89,17 @@ def layers_module():
     http_util = type(sys)("app.utils.http")
     async def _hgb(url, **k): return b""
     http_util.http_get_bytes = _hgb
+    class _EarthEngineRateLimitedError(Exception):
+        def __init__(self, message: str = "", sa_name=None):
+            super().__init__(message)
+            self.sa_name = sa_name
+    http_util.EarthEngineRateLimitedError = _EarthEngineRateLimitedError
     sys.modules["app.utils.http"] = http_util
+
+    ee_tile_fetch_mod = type(sys)("app.utils.ee_tile_fetch")
+    async def _fetch_tile(*_a, **_k): return b""
+    ee_tile_fetch_mod.fetch_tile_with_rotation = _fetch_tile
+    sys.modules["app.utils.ee_tile_fetch"] = ee_tile_fetch_mod
 
     from app.api import layers
     return layers


### PR DESCRIPTION
## Summary

- Resolve a causa raiz dos 503 `ee_unavailable` sob carga: o pool de Service Accounts do GEE não reagia a 429 do download de tile, e a URL cacheada em Redis ficava acoplada à SA penalizada (token assinado por `getMapId`). A rotação isolada do worker era teatral porque o retry continuava batendo na mesma URL.
- Introduz exceção tipada `EarthEngineRateLimitedError` em `app/utils/http.py` e helper `fetch_tile_with_rotation` em `app/utils/ee_tile_fetch.py` que orquestra: invalida o meta-cache da URL → rotaciona a SA do worker (`trigger="http_429"`) → regenera URL via `url_factory()` do caller → retenta uma única vez.
- Adota o helper nos três call sites de tiles (`layers.py`, `imagery.py`, `embedding_maps/router.py`); aumenta `http_get_bytes` timeout de 10s → 20s configurável; expõe quatro métricas Prometheus por SA (`gee_sa_http_429_total`, `gee_sa_rotation_total`, `gee_sa_in_cooldown`, `gee_tile_url_regen_total`); documenta no runbook como expandir o pool de SAs (capacidade não escala com código sozinho).

## Componentes (alinhados com a spec)

| | Componente | Arquivos |
|---|---|---|
| C1 | Exceção tipada | `app/utils/http.py` |
| C2 | Helper de rotação | `app/utils/ee_tile_fetch.py` (novo) |
| C3 | Adoção nos call sites | `app/api/layers.py`, `app/api/imagery.py`, `app/modules/embedding_maps/router.py` |
| C4 | Timeout configurável | `settings.toml`, `app/utils/http.py` |
| C5 | Métricas Prometheus | `app/core/metrics.py`, `app/core/gee_pool.py` |
| C6 | Runbook operacional | `docs/deploy-runbook.md` |

Spec: `docs/superpowers/specs/2026-05-12-tiles-ee-429-rotation-cache-invalidation-design.md`
Plano: `docs/superpowers/plans/2026-05-12-tiles-ee-429-rotation-cache-invalidation.md`

## Mudanças adicionais (descobertas durante implementação)

- `WorkerGEEManager.rotate_on_429` ganhou parâmetro `trigger: str = "rest_api_429"`; helper passa `trigger="http_429"` via `functools.partial`. Cooldown da SA antiga agora respeita o trigger (15s para HTTP, 60s para REST API).
- Gauge `gee_sa_in_cooldown` auto-reseta em `_assign` (eliminação de janela de falso positivo entre cooldown expirar e próxima leitura de `get_metrics`).
- Em `layers.py`, circuit breaker hoistado para fora do `if expired:` e agora chama `record_failure()` em 429 persistente — corrige cegueira do CB para a classe de falha mais relevante sob carga.
- Helper invalida cache **antes** da rotação (self-healing mesmo se `rotate_on_429` falhar).
- `asyncio.get_event_loop()` substituído por `get_running_loop()` em todas as ocorrências em código novo + nos arquivos modificados.

## Test plan

- [x] Suite unit + integration verde localmente: `pytest tests/unit tests/integration` → **112 passed**.
- [x] Novos testes adicionados:
  - `tests/unit/test_cache_delete_meta.py` — contrato de `adelete_meta`.
  - `tests/unit/test_http_typed_exception.py` — `EarthEngineRateLimitedError` propagada em 429 persistente, com `sa_name`.
  - `tests/unit/test_gee_pool_metrics.py` — registro Prometheus dos 3 counters/gauges.
  - `tests/unit/test_ee_tile_fetch.py` — 4 cenários do helper (happy path, ciclo completo de 429, 429 persistente, falha do `url_factory`).
  - `tests/integration/test_tile_handlers_propagate_status.py` — branch novo `EarthEngineRateLimitedError → 503/ee_unavailable` em `_serve_tile`, com asserção de `breaker.record_failure()`.
- [ ] **Deploy canário** (1 réplica de 20) seguindo `docs/deploy-runbook.md`. Monitorar por 30 min:
  - Taxa de 503 deve cair (baseline ~9%, alvo <2%).
  - `gee_sa_rotation_total{trigger="http_429"}` cresce em picos e estabiliza.
  - `gee_tile_url_regen_total` confirma invalidação + regeneração ocorrendo.
  - `gee_sa_in_cooldown` reflete cooldown real (gauge oscila com 429 events, não fica preso em 1).
- [ ] Rollout completo se métricas estáveis.
- [ ] **Pós-deploy:** avaliar expansão do pool de SAs no GCP se `gee_sa_rotation_total` mostrar oscilação sustentada entre as 2 SAs atuais — runbook documenta o procedimento de hot-reload.

## Issues conhecidos (follow-up, não bloqueantes)

- `imagery.py` e `embedding_maps/router.py` não chamam `breaker.record_failure()` em 429 persistente (esses endpoints não têm CB configurado atualmente — consistência, não regressão).
- `gee_tile_url_regen_total` não tem teste de counter dedicado (cobertura indireta via `test_ee_tile_fetch.py`).
- `asyncio.get_event_loop()` residual em `embedding_maps/router.py:430` (função `get_stats`, fora do escopo).
- Suite de integração com Redis fake (`test_tile_rotation.py`) prevista na spec não foi criada (plano não a incluiu).
- Logs do helper não incluem `request_id` propagado pelo `RequestIdMiddleware` (cosmético para correlação).

## Capacidade — observação importante

O fix mitiga picos transitórios mas não muda o teto sustentável. Com apenas 2 SAs (`ee-lapig-tvi5`, `ee-lapig-tvi7`) atendendo 20 réplicas, sob carga real ambas saturam e a rotação produz oscilação A→B→A. A nova seção do runbook documenta como provisionar SAs adicionais e fazer hot-reload do pool sem redeploy.

## Nota sobre o commit `7111cef`

O commit `docs(tiles): runbook de expansão do pool de SAs do GEE` inclui também a seção pré-existente "Purge continuado via Celery beat" — modificações locais no runbook que estavam pendentes antes desta entrega ficaram misturadas. O conteúdo está correto, ambas as seções são legítimas; apenas a mensagem de commit não reflete que inclui ambas. Se desejado, posso splitar em commits separados antes do merge.