### PR TITLE
feat(tiles): rebalanceamento de LB + observabilidade de cache + circuit breaker no pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,10 @@ RATE_LIMIT_BURST=100
 # Tempo de vida da URL do Earth Engine (horas)
 LIFESPAN_URL=24
 
+# Tamanho do cache local LRU em memória por pod (número de tiles).
+# Em produção, dimensionar com base no RAM disponível (~30 KB por tile).
+LOCAL_CACHE_SIZE=1000
+
 # =============================================================================
 # CORS
 # =============================================================================

--- a/DEPLOY-PROD.md
+++ b/DEPLOY-PROD.md
@@ -1,5 +1,14 @@
 # Deploy em Produção — Pool de Service Accounts GEE
 
+> **Nota — Topologia atual (Docker Swarm).** A produção real roda como stack
+> Swarm `prod_tiles`, com 20 réplicas do serviço `tile` distribuídas entre
+> `vm1` e `vm2`. O arquivo de stack autoritativo é
+> [`config/swarm/prod.compose.yml`](config/swarm/prod.compose.yml) no repositório,
+> deployado em `/glusterfs/aplications/services/tiles/prod.compose.yml` via
+> `docker stack deploy`. Para rebalanceamento de load balancer e remoção de
+> sticky session, consulte
+> [`docs/RUNBOOK_LB_REBALANCING.md`](docs/RUNBOOK_LB_REBALANCING.md).
+
 ## Pré-requisitos
 
 - [ ] Todos os 12 arquivos `.json` de SAs no diretório `.service-accounts/` de cada instância

--- a/app/api/imagery.py
+++ b/app/api/imagery.py
@@ -26,6 +26,7 @@ from app.cache.cache import (
 )
 from app.core.config import logger, settings
 from app.core.errors import tile_error_response
+from app.core.metrics import observe_cache_hit
 from app.middleware.rate_limiter import limit_imagery
 from app.core.gee_pool import gee_retry
 from app.utils.ee_compute import compute_value
@@ -353,7 +354,10 @@ async def catalog(
     cached = await get_meta(cache_key)
     if cached:
         logger.info(f"Catalog cache HIT: {cache_key}")
+        observe_cache_hit(layer="imagery", type_="catalog_hit")
         return JSONResponse(cached, headers={"X-Cache": "HIT"})
+
+    observe_cache_hit(layer="imagery", type_="catalog_miss")
 
     # EE query
     region = _point_to_region(lat, lon, bufferMeters)
@@ -412,17 +416,21 @@ async def image_tile(
     tile_key = _tile_cache_key(layer, imageId, visparam, x, y, z)
     png_bytes = await get_png(tile_key)
     if png_bytes:
+        observe_cache_hit(layer="imagery", type_="png_hit")
         return StreamingResponse(
             io.BytesIO(png_bytes),
             media_type="image/png",
             headers={"X-Cache": "HIT", "X-Image-Id": imageId},
         )
 
+    observe_cache_hit(layer="imagery", type_="png_miss")
+
     # 2 ▸ Lock distribuído: evita que dois workers gerem o mesmo tile
     async with tile_lock(tile_key) as should_generate:
         if not should_generate:
             png_bytes = await get_png(tile_key)
             if png_bytes:
+                observe_cache_hit(layer="imagery", type_="png_hit")
                 return StreamingResponse(
                     io.BytesIO(png_bytes),
                     media_type="image/png",
@@ -437,6 +445,7 @@ async def image_tile(
             or (datetime.now() - datetime.fromisoformat(meta["date"])).total_seconds() / 3600
             > settings.LIFESPAN_URL
         )
+        observe_cache_hit(layer="imagery", type_="meta_miss" if expired else "meta_hit")
 
         if expired:
             try:

--- a/app/api/layers.py
+++ b/app/api/layers.py
@@ -23,6 +23,7 @@ from app.cache.cache import (
     aget_png as get_png, aset_png as set_png,  # bytes (tile)
     aget_meta as get_meta, aset_meta as set_meta,  # {"url": str, "date": iso}
     atile_lock as tile_lock,
+    PNG_TTL, PNG_TTL_HISTORICAL,
 )
 from app.core.circuit_breaker import get_ee_circuit_breaker
 from app.core.config import logger, settings
@@ -483,7 +484,10 @@ async def _serve_tile(layer: str,
     # 1 ▸ PNG já cacheado?
     png_bytes = await get_png(file_cache)
     if png_bytes:
+        observe_cache_hit(layer=layer, type_="png_hit")
         return StreamingResponse(io.BytesIO(png_bytes), media_type="image/png")
+
+    observe_cache_hit(layer=layer, type_="png_miss")
 
     # 2 ▸ Lock distribuído: evita que dois workers gerem o mesmo tile
     async with tile_lock(file_cache) as should_generate:
@@ -491,6 +495,7 @@ async def _serve_tile(layer: str,
             # Outro worker gerou enquanto esperávamos — tenta o cache
             png_bytes = await get_png(file_cache)
             if png_bytes:
+                observe_cache_hit(layer=layer, type_="png_hit")
                 return StreamingResponse(io.BytesIO(png_bytes), media_type="image/png")
             # Se ainda não tem, gera normalmente (lock expirou ou falhou)
 
@@ -506,6 +511,7 @@ async def _serve_tile(layer: str,
             (datetime.now() - datetime.fromisoformat(meta["date"])).total_seconds()/3600
             > settings.LIFESPAN_URL
         )
+        observe_cache_hit(layer=layer, type_="meta_miss" if expired else "meta_hit")
         if expired:
             # Circuit breaker: fail-fast quando EE está degradado. Libera
             # threads EE para outros endpoints e evita retry storm.
@@ -603,8 +609,12 @@ async def _serve_tile(layer: str,
                 layer=layer,
             )
             logger.info(f"Tile downloaded: {file_cache} ({len(png_bytes)} bytes), saving to cache...")
-            await set_png(file_cache, png_bytes)
-            logger.info(f"Tile cached: {file_cache}")
+            # Anos passados são imutáveis (mosaico/best image já consolidado) —
+            # cacheia por 1 ano. Ano corrente pode ainda receber novas passagens
+            # de satélite, então mantém TTL curto de 30 dias.
+            tile_ttl = PNG_TTL_HISTORICAL if year < datetime.utcnow().year else PNG_TTL
+            await set_png(file_cache, png_bytes, ttl=tile_ttl)
+            logger.info(f"Tile cached: {file_cache} (ttl={tile_ttl}s)")
             return StreamingResponse(io.BytesIO(png_bytes), media_type="image/png")
         except EarthEngineRateLimitedError as exc:
             logger.warning(

--- a/app/cache/cache.py
+++ b/app/cache/cache.py
@@ -11,8 +11,9 @@ from typing import Any, Optional
 from app.cache.cache_hybrid import tile_cache
 
 # TTLs otimizados para alta performance
-PNG_TTL = 30 * 24 * 3600   # 30 dias para tiles (eram 24h)
-META_TTL = 7 * 24 * 3600    # 7 dias para metadados (eram 6h)
+PNG_TTL = 30 * 24 * 3600              # 30 dias — tiles do ano corrente
+PNG_TTL_HISTORICAL = 365 * 24 * 3600  # 1 ano — rasters de anos passados (imutáveis)
+META_TTL = 7 * 24 * 3600              # 7 dias para metadados (eram 6h)
 
 # ----------------------- helpers síncronos (compatibilidade) ----------------------------- #
 # NOTA: Estas funções são para compatibilidade com código legado (ex: Celery tasks em prefork)

--- a/app/cache/cache_hybrid.py
+++ b/app/cache/cache_hybrid.py
@@ -45,10 +45,11 @@ class HybridTileCache:
         self.local_cache_size = local_cache_size
 
         # Configurações de TTL otimizadas
-        self.PNG_TTL = 30 * 24 * 3600   # 30 dias para tiles
-        self.META_TTL = 7 * 24 * 3600    # 7 dias para metadados
-        self.URL_TTL = 24 * 3600         # 24 horas para URLs do Earth Engine
-        self.LOCK_TTL = 60               # Lock expira em 60s (safety net)
+        self.PNG_TTL = 30 * 24 * 3600        # 30 dias — tiles do ano corrente
+        self.PNG_TTL_HISTORICAL = 365 * 24 * 3600  # 1 ano — rasters imutáveis
+        self.META_TTL = 7 * 24 * 3600         # 7 dias para metadados
+        self.URL_TTL = 24 * 3600              # 24h — limite imposto pelo Earth Engine
+        self.LOCK_TTL = 60                    # Lock expira em 60s (safety net)
 
         # Pool de conexões
         self._redis_pool = None

--- a/app/cache/cache_hybrid.py
+++ b/app/cache/cache_hybrid.py
@@ -495,4 +495,5 @@ tile_cache = HybridTileCache(
     redis_url=REDIS_URL,
     s3_endpoint=settings.get("S3_ENDPOINT", "http://minio:9000"),
     s3_bucket=settings.get("S3_BUCKET", "tiles-cache"),
+    local_cache_size=int(settings.get("LOCAL_CACHE_SIZE", 1000)),
 )

--- a/app/core/gee_pool.py
+++ b/app/core/gee_pool.py
@@ -49,6 +49,24 @@ class ServiceAccountInfo:
 
 
 # ---------------------------------------------------------------------------
+# Erros
+# ---------------------------------------------------------------------------
+
+
+class PoolExhaustedError(RuntimeError):
+    """Sinalizado quando todas as SAs estão em cooldown além do timeout aceitável.
+
+    O caller deve mapear para HTTP 503 com cabeçalho ``Retry-After``.
+    """
+
+    def __init__(self, retry_after: float, message: str | None = None) -> None:
+        self.retry_after = float(retry_after)
+        super().__init__(
+            message or f"Pool de SAs esgotado, retry após {self.retry_after:.1f}s"
+        )
+
+
+# ---------------------------------------------------------------------------
 # ServiceAccountPool — coordenação centralizada via Redis
 # ---------------------------------------------------------------------------
 
@@ -152,11 +170,14 @@ class ServiceAccountPool:
             ServiceAccountInfo com credenciais carregadas.
 
         Raises:
-            RuntimeError: Se nenhuma SA estiver disponível.
+            PoolExhaustedError: Quando todas as SAs estão em cooldown e o tempo
+                de espera necessário excede ``GEE_SA_ACQUIRE_TIMEOUT_SECONDS``.
+                O caller deve mapear para HTTP 503 com ``Retry-After``.
+            RuntimeError: Quando o pool não possui nenhuma SA registrada.
         """
         exclude = exclude or set()
         now = time.time()
-        cooldown_seconds = settings.get("GEE_SA_COOLDOWN_SECONDS", 60)
+        acquire_timeout = float(settings.get("GEE_SA_ACQUIRE_TIMEOUT_SECONDS", 2))
 
         # Buscar SAs ordenadas por uso (menor primeiro) com desempate aleatório
         # entre scores iguais — evita viés lexicográfico do zrangebyscore que
@@ -192,9 +213,25 @@ class ServiceAccountPool:
             # SA disponível — adquirir
             return self._assign(sa_name, worker_id)
 
-        # Nenhuma SA livre — esperar pelo cooldown mais curto
+        # Nenhuma SA livre — política do circuit breaker
         if best_sa is not None:
-            wait_time = min(best_cooldown_end - now, cooldown_seconds)
+            wait_time = best_cooldown_end - now
+            if wait_time > acquire_timeout:
+                # Espera longa: fail-fast em vez de bloquear o worker.
+                logger.warning(
+                    f"Pool exhausted: todas as SAs em cooldown, "
+                    f"próximo disponível em {wait_time:.1f}s (timeout={acquire_timeout}s). "
+                    f"Retornando PoolExhaustedError."
+                )
+                try:
+                    from app.core.metrics import gee_pool_exhausted_total
+                    gee_pool_exhausted_total.inc()
+                except Exception:
+                    pass
+                raise PoolExhaustedError(retry_after=wait_time)
+
+            # Espera curta aceitável — preserva comportamento antigo para
+            # casos benignos onde uma SA está a poucos segundos do retorno.
             logger.warning(
                 f"Todas as SAs em cooldown. Aguardando {wait_time:.1f}s pela SA {best_sa}"
             )

--- a/app/core/metrics.py
+++ b/app/core/metrics.py
@@ -50,6 +50,11 @@ gee_sa_in_cooldown = Gauge(
     labelnames=("sa_name",),
 )
 
+gee_pool_exhausted_total = Counter(
+    "gee_pool_exhausted_total",
+    "Eventos de exaustão do pool: todas as SAs em cooldown além do timeout aceitável.",
+)
+
 # Counter instrumentado em app/utils/ee_tile_fetch.py (Task 4 do plano).
 # Definição vive aqui para manter as métricas do pool no mesmo módulo.
 gee_tile_url_regen_total = Counter(

--- a/config/swarm/prod.compose.yml
+++ b/config/swarm/prod.compose.yml
@@ -1,0 +1,310 @@
+version: '3.8'
+x-common-config: &common-config
+  image: lapig/tiles:prod_latest
+  labels:
+    com.docker.compose.project: tiles
+  volumes:
+    - /etc/localtime:/etc/localtime:ro
+    - /glusterfs/aplications/secrets/gee-sa-pool:/app/.service-accounts:ro
+  networks:
+    - traefik-public
+    - tiles-valkey-network
+    - mongo-network
+
+x-common-celery-env: &common-celery-env
+  GEE_SA_DIRECTORY: /app/.service-accounts/
+  LIFESPAN_URL: "24"
+  LOG_LEVEL: WARNING
+  REDIS_URL: redis://tile-valkey:6379
+  CELERY_BROKER_URL: redis://tile-valkey:6379/1
+  CELERY_RESULT_BACKEND: redis://tile-valkey:6379/2
+  S3_ACCESS_KEY: 70432355FDB551434E63
+  S3_BUCKET: cache
+  S3_ENDPOINT: https://s3-tiles:8333
+  S3_SECRET_KEY: M5cRMmsO9ns81Znm9LJafKHJMhM1zi3NvD4WAGe7
+  S3_USE_SSL: "false"
+  S3_VERIFY_SSL: "false"
+  SKIP_GEE_INIT: "false"
+  TILES_ENV: production
+  MONGODB_URL: mongodb://mongoprod:27017
+  MONGODB_DB: tvi
+
+x-common-tile-env: &common-tile-env
+  ALLOW_ORIGINS: http://localhost:4200
+  GEE_SA_DIRECTORY: /app/.service-accounts/
+  LIFESPAN_URL: "24"
+  LOCAL_CACHE_SIZE: "10000"
+  LOG_LEVEL: WARNING
+  MAX_REQUESTS: "50000"
+  MAX_REQUESTS_JITTER: "5000"
+  PORT: "8080"
+  RATE_LIMIT_BURST: "500"
+  RATE_LIMIT_PER_MINUTE: "5000"
+  REDIS_URL: redis://tile-valkey:6379
+  S3_ACCESS_KEY: 70432355FDB551434E63
+  S3_BUCKET: cache
+  S3_ENDPOINT: http://s3-tiles:8333
+  S3_SECRET_KEY: M5cRMmsO9ns81Znm9LJafKHJMhM1zi3NvD4WAGe7
+  S3_USE_SSL: "false"
+  S3_VERIFY_SSL: "false"
+  SKIP_GEE_INIT: "false"
+  TILES_ENV: production
+  WORKER_CONNECTIONS: "4000"
+  WORKERS: "8"
+  MONGODB_URL: mongodb://mongoprod:27017
+  MONGODB_DB: tvi
+  CELERY_BROKER_URL: redis://tile-valkey:6379/1
+  CELERY_RESULT_BACKEND: redis://tile-valkey:6379/2
+
+x-deploy-celery-worker: &deploy-celery-worker
+  mode: replicated
+  placement:
+    preferences:
+      - spread: node.labels.name
+  labels:
+    traefik.enable: 'false'
+  restart_policy:
+    condition: any
+  resources:
+    limits:
+      memory: 2g
+    reservations:
+      memory: 1g
+
+x-deploy-celery-light: &deploy-celery-light
+  mode: replicated
+  placement:
+    preferences:
+      - spread: node.labels.name
+  labels:
+    traefik.enable: 'false'
+  restart_policy:
+    condition: any
+  resources:
+    limits:
+      memory: 512m
+    reservations:
+      memory: 256m
+
+# ========================================
+# Services
+# ========================================
+services:
+  # ========================================
+  # Celery Services
+  # ========================================
+  celery_beat:
+    <<: *common-config
+    command:
+      - celery
+      - -A
+      - app.tasks.celery_app
+      - beat
+      - --loglevel=info
+    environment:
+      <<: *common-celery-env
+    deploy:
+      <<: *deploy-celery-light
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.name == vm1
+
+  celery_flower:
+    <<: *common-config
+    command:
+      - celery
+      - -A
+      - app.tasks.celery_app
+      - flower
+      - --loglevel=info
+      - --port=5555
+      - --basic-auth=admin:lapig2024
+    environment:
+      <<: *common-celery-env
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.name == vm2
+      labels:
+        traefik.enable: 'true'
+        traefik.http.routers.flower.rule: Host(`flower-tiles.lapig.iesa.ufg.br`)
+        traefik.http.routers.flower.tls: 'true'
+        traefik.http.routers.flower.tls.certresolver: le
+        traefik.http.routers.flower.entrypoints: websecure
+        traefik.http.routers.flower.service: flower
+        traefik.http.services.flower.loadbalancer.server.port: '5555'
+      restart_policy:
+        condition: any
+      resources:
+        limits:
+          memory: 512m
+        reservations:
+          memory: 256m
+
+  celery_worker_default_high:
+    <<: *common-config
+    command:
+      - celery
+      - -A
+      - app.tasks.celery_app
+      - worker
+      - --loglevel=info
+      - --concurrency=8
+      - --max-tasks-per-child=1000
+      - --pool=prefork
+      - --queues=default,high_priority,standard
+      - --without-gossip
+      - --without-mingle
+      - --without-heartbeat
+    environment:
+      <<: *common-celery-env
+    deploy:
+      <<: *deploy-celery-worker
+      replicas: 2
+
+  celery_worker_default_low:
+    <<: *common-config
+    command:
+      - celery
+      - -A
+      - app.tasks.celery_app
+      - worker
+      - --loglevel=info
+      - --concurrency=8
+      - --max-tasks-per-child=1000
+      - --pool=prefork
+      - --queues=default,low_priority,standard
+      - --without-gossip
+      - --without-mingle
+      - --without-heartbeat
+    environment:
+      <<: *common-celery-env
+    deploy:
+      <<: *deploy-celery-worker
+      replicas: 2
+
+  celery_worker_high_priority:
+    <<: *common-config
+    command:
+      - celery
+      - -A
+      - app.tasks.celery_app
+      - worker
+      - --loglevel=info
+      - --concurrency=8
+      - --max-tasks-per-child=1000
+      - --pool=prefork
+      - --queues=high_priority
+      - --without-gossip
+      - --without-mingle
+      - --without-heartbeat
+    environment:
+      <<: *common-celery-env
+    deploy:
+      <<: *deploy-celery-worker
+      replicas: 2
+      resources:
+        limits:
+          memory: 3g
+        reservations:
+          memory: 1536m
+
+  celery_worker_cache:
+    <<: *common-config
+    command:
+      - celery
+      - -A
+      - app.tasks.celery_app
+      - worker
+      - --loglevel=info
+      - --concurrency=4
+      - --max-tasks-per-child=1000
+      - --pool=prefork
+      - --queues=default,cache_operations,maintenance
+      - --without-gossip
+      - --without-mingle
+      - --without-heartbeat
+    environment:
+      <<: *common-celery-env
+    deploy:
+      <<: *deploy-celery-worker
+      replicas: 2
+      resources:
+        limits:
+          memory: 4g
+        reservations:
+          memory: 2g
+
+  # ========================================
+  # Tile Services (distribuído entre vm1 e vm2)
+  # 20 réplicas (max 10 por nó) para escalar throughput.
+  # Subdomínios tm1..tm5 + tiles são mantidos por compatibilidade com
+  # navegadores que paralelizam por hostname; o roteamento real usa o mesmo
+  # service tiles-loadbalancer.
+  # ========================================
+  tile:
+    <<: *common-config
+    command:
+      - uvicorn
+      - --host
+      - 0.0.0.0
+      - --port
+      - '8080'
+      - --workers
+      - '8'
+      - main:app
+      - --timeout-keep-alive
+      - '300'
+    environment:
+      <<: *common-tile-env
+    deploy:
+      mode: replicated
+      replicas: 20
+      placement:
+        max_replicas_per_node: 10
+        preferences:
+          - spread: node.labels.name
+      labels:
+        - "com.docker.compose.project=tiles"
+        - "com.docker.compose.service=api-tiles"
+        - "traefik.enable=true"
+        - "traefik.http.routers.tiles-unified.rule=Host(`tiles.lapig.iesa.ufg.br`) || Host(`tm1.lapig.iesa.ufg.br`) || Host(`tm2.lapig.iesa.ufg.br`) || Host(`tm3.lapig.iesa.ufg.br`) || Host(`tm4.lapig.iesa.ufg.br`) || Host(`tm5.lapig.iesa.ufg.br`)"
+        - "traefik.http.routers.tiles-unified.tls=true"
+        - "traefik.http.routers.tiles-unified.tls.certresolver=le"
+        - "traefik.http.routers.tiles-unified.entrypoints=websecure"
+        - "traefik.http.routers.tiles-unified.service=tiles-loadbalancer"
+        - "traefik.http.routers.tiles-unified.middlewares=rate-limit-tiles@file,compress@file,cache-headers-tiles@file,upload-bypass@file"
+        - "traefik.http.services.tiles-loadbalancer.loadbalancer.server.port=8080"
+        # Sticky cookie removido — causava desbalanceamento (cliente pesado
+        # ficava pinned a um único pod, gerando 17× a carga mediana).
+        # Cache locality é preservada pelo cache local maior (LOCAL_CACHE_SIZE)
+        # mais Valkey/S3 compartilhados. Detalhes em
+        # docs/RUNBOOK_LB_REBALANCING.md.
+        - "traefik.http.services.tiles-loadbalancer.loadbalancer.healthcheck.path=/health/light"
+        - "traefik.http.services.tiles-loadbalancer.loadbalancer.healthcheck.interval=10s"
+        - "traefik.http.services.tiles-loadbalancer.loadbalancer.healthcheck.timeout=3s"
+        - "traefik.http.services.tiles-loadbalancer.loadbalancer.healthcheck.scheme=http"
+        - "traefik.http.services.tiles-loadbalancer.loadbalancer.passhostheader=true"
+      update_config:
+        parallelism: 2
+        delay: 15s
+        order: start-first
+        failure_action: rollback
+      restart_policy:
+        condition: any
+      resources:
+        limits:
+          memory: 4g
+        reservations:
+          memory: 2g
+
+networks:
+  traefik-public:
+    external: true
+  tiles-valkey-network:
+    external: true
+  mongo-network:
+    external: true

--- a/docs/RUNBOOK_LB_REBALANCING.md
+++ b/docs/RUNBOOK_LB_REBALANCING.md
@@ -1,0 +1,202 @@
+# Runbook — Rebalanceamento do Load Balancer de Tiles
+
+## Sintoma
+
+Um pod do serviço de tiles (`prod_tiles_tile.<N>`) recebe carga muito superior à
+mediana — observado até **17× a mediana** para `tile.4` — enquanto outros pods
+operam ociosos. O desequilíbrio é **intermitente** e correlacionado com sessões
+HTTP longas de clientes pesados (ex.: campanhas TVI que renderizam muitos tiles
+em sequência).
+
+## Causa raiz
+
+O Traefik está configurado com **sticky session por cookie** no service
+`tiles-loadbalancer`:
+
+```
+traefik.http.services.tiles-loadbalancer.loadbalancer.sticky.cookie = true
+traefik.http.services.tiles-loadbalancer.loadbalancer.sticky.cookie.name = tiles_session
+```
+
+Com sticky cookie ativo, **todas as requisições HTTP de um mesmo cliente vão
+para o mesmo pod backend indefinidamente**. A motivação histórica era cache
+locality (cada pod tem um `local_cache` LRU in-memory de 1000 tiles), mas a
+estratégia escolhida é errada — o desejado seria afinidade **tile → pod**
+(consistent hashing por URL), não **cliente → pod**.
+
+Quando um cliente carrega tiles em massa (ex.: 5000 tiles para uma campanha),
+ele concentra todo esse tráfego em um único pod. O `wrr` (weighted round
+robin) do Traefik só distribui o cookie inicial; depois disso, o cookie
+governa.
+
+## Topologia atual
+
+| Aspecto | Valor |
+|---------|-------|
+| Stack Swarm | `prod_tiles` |
+| Réplicas | 20 (max 10 por nó, spread entre vm1 e vm2) |
+| Nodes | vm1, vm2 |
+| Load balancer | Traefik v3.6.7 |
+| Strategy | `wrr` |
+| Discovery | Traefik enumera as 20 réplicas individualmente (IPs `10.0.10.x:8080`) |
+| Cache local | LRU in-memory de 1000 tiles por pod (default) |
+| Cache compartilhado | Valkey (metadados) + S3 (PNGs) |
+
+## Inspeção do estado atual
+
+### Listar pods de tile
+
+```bash
+ssh prod-lapig "docker ps --format 'table {{.Name}}\t{{.Status}}' \
+  | grep prod_tiles_tile"
+```
+
+### Distribuição de CPU/RAM por pod
+
+```bash
+ssh prod-lapig "docker stats --no-stream \
+  \$(docker ps -q -f name=prod_tiles_tile)"
+```
+
+Desvio padrão alto entre pods (>3% CPU) indica desbalanceamento ativo.
+
+### Configuração do Traefik (verifica se sticky está ativo)
+
+```bash
+ssh prod-lapig "TRAEFIK_CID=\$(docker ps -q -f name=traefik | head -1); \
+  docker exec \$TRAEFIK_CID wget -qO- http://localhost:8080/api/http/services \
+  | python3 -c 'import sys,json; \
+    [print(json.dumps(s, indent=2)) for s in json.load(sys.stdin) \
+     if \"tiles-loadbalancer\" in s.get(\"name\",\"\")]' \
+  | grep -A 8 sticky"
+```
+
+Esperado **após o fix**: ausência de campo `sticky` no output.
+
+### Health dos backends
+
+```bash
+ssh prod-lapig "TRAEFIK_CID=\$(docker ps -q -f name=traefik | head -1); \
+  docker exec \$TRAEFIK_CID wget -qO- http://localhost:8080/api/http/services \
+  | python3 -c 'import sys,json; s=[x for x in json.load(sys.stdin) \
+    if \"tiles-loadbalancer\" in x.get(\"name\",\"\")][0]; \
+    print(json.dumps(s.get(\"serverStatus\",{}), indent=2))'"
+```
+
+Esperado: 20 endereços, todos `UP`.
+
+## Procedimento de mudança
+
+### Pré-requisitos
+
+- Acesso a `vm1` ou `vm2` como usuário `suporte`.
+- Versão recém-aprovada de `config/swarm/prod.compose.yml` no repositório
+  (branch `feat/tiles-p1-remove-sticky-cookie`).
+
+### Passo 1 — Sincronizar o arquivo do repo com o host
+
+A partir de uma checkout local do repo, com a branch correta:
+
+```bash
+scp config/swarm/prod.compose.yml \
+  prod-lapig:/glusterfs/aplications/services/tiles/prod.compose.yml
+```
+
+Validar diff antes do deploy:
+
+```bash
+ssh prod-lapig "diff /glusterfs/aplications/services/tiles/prod.compose.yml \
+  <(cat /glusterfs/aplications/services/tiles/prod.compose.yml.bak)"
+```
+
+(Fazer o backup antes do scp.)
+
+### Passo 2 — Deploy do stack
+
+Em vm1 (manager node):
+
+```bash
+ssh prod-lapig "cd /glusterfs/aplications/services/tiles && \
+  docker stack deploy -c prod.compose.yml prod_tiles --with-registry-auth"
+```
+
+A diretiva `update_config: order: start-first, parallelism: 2` garante rolling
+update sem downtime: 2 pods por vez, novo sobe antes do antigo cair.
+
+### Passo 3 — Verificação imediata
+
+1. **Confirmar ausência do Set-Cookie:**
+
+   ```bash
+   curl -sI https://tiles.lapig.iesa.ufg.br/health/light \
+     | grep -i 'set-cookie' || echo 'OK: sem sticky cookie'
+   ```
+
+2. **Confirmar nivelamento de CPU** (esperado <0.5% de desvio padrão em ~15 min
+   após o deploy completo):
+
+   ```bash
+   watch -n 5 'ssh prod-lapig "docker stats --no-stream \
+     \$(docker ps -q -f name=prod_tiles_tile)"'
+   ```
+
+3. **Confirmar `LOCAL_CACHE_SIZE=10000` aplicado:**
+
+   ```bash
+   ssh prod-lapig "docker inspect \
+     \$(docker ps -q -f name=prod_tiles_tile | head -1) \
+     | grep -A 1 LOCAL_CACHE_SIZE"
+   ```
+
+### Passo 4 — Monitoramento por 24 h
+
+- Métricas Prometheus: `tile_requests_total` por pod (via label `pod`/`instance`
+  agregada no Grafana).
+- Logs do Valkey: medir aumento de carga (esperado leve aumento, com
+  `LOCAL_CACHE_SIZE=10000` o impacto é pequeno).
+- Métrica `gee_sa_in_cooldown`: esperado redução pelo nivelamento de carga.
+
+## Rollback
+
+Se o desempenho cair ou cache local degradar significativamente:
+
+```bash
+ssh prod-lapig "cp /glusterfs/aplications/services/tiles/prod.compose.yml.bak \
+  /glusterfs/aplications/services/tiles/prod.compose.yml && \
+  cd /glusterfs/aplications/services/tiles && \
+  docker stack deploy -c prod.compose.yml prod_tiles --with-registry-auth"
+```
+
+O rolling update restaura os pods com a config anterior em ~2-3 minutos.
+
+## Justificativa técnica para remoção
+
+| Argumento | Detalhe |
+|-----------|---------|
+| Serviço stateless | Toda persistência fica em Valkey + S3 compartilhados — pods não mantêm estado de sessão |
+| Cache local pequeno | 1000 tiles ≈ 30 MB por pod; é caching de hot path, não dado crítico |
+| Penalidade de miss baixa | Cache miss local cai para Valkey (sub-ms), depois S3 (~10 ms) — sem ir ao GEE |
+| Compensação aplicada | `LOCAL_CACHE_SIZE=10000` no `x-common-tile-env` aumenta 10× o cache local; 300 MB de 4 GB de limite por pod |
+| Métrica observável | Após mudança, `tile_duration_seconds` deve permanecer no mesmo p99; se subir, ajustar `LOCAL_CACHE_SIZE` |
+
+## Investigação adicional para cliente pesado (se reincidir após fix)
+
+Caso o desequilíbrio persista mesmo sem o cookie, suspeitar de:
+
+1. **Keep-alive HTTP/1.1 longo** — `--timeout-keep-alive 300` no uvicorn pode
+   manter uma conexão de cliente no mesmo pod por 5 min. Não é problema se
+   bem distribuído; é problema se um único IP gera 1000 req/s nessa conexão.
+2. **Single client behaviour** — identificar via:
+
+   ```bash
+   ssh prod-lapig "docker service logs prod_tiles_tile --since 1h 2>&1 \
+     | grep 'GET /api/layers' \
+     | awk '{print \$NF}' \
+     | sort | uniq -c | sort -rn | head -20"
+   ```
+
+   Se um único IP domina, considerar rate limit por IP no Traefik.
+
+3. **Burst de campanha programado** — bater com o cron de Celery
+   (`celery_beat`) ou jobs de pre-aquecimento de cache. Esses devem rodar
+   contra Valkey/S3 direto, não via load balancer.

--- a/main.py
+++ b/main.py
@@ -167,6 +167,26 @@ app.add_middleware(
     max_age=3600,
 )
 
+from app.core.gee_pool import PoolExhaustedError
+
+
+@app.exception_handler(PoolExhaustedError)
+async def handle_pool_exhausted(request: Request, exc: PoolExhaustedError) -> Response:
+    """Mapeia exaustão do pool de SAs para 503 com cabeçalho ``Retry-After``."""
+    retry_after = max(1, int(exc.retry_after) + 1)
+    logger.warning(
+        f"PoolExhausted handler: 503 retry_after={retry_after}s "
+        f"path={request.url.path}"
+    )
+    return Response(
+        status_code=503,
+        headers={
+            "Retry-After": str(retry_after),
+            "X-Error-Reason": "gee_pool_exhausted",
+        },
+    )
+
+
 @app.get("/metrics", include_in_schema=False)
 async def metrics() -> Response:
     """Endpoint Prometheus. Exposto sem rate-limit para scraping interno.

--- a/settings.toml
+++ b/settings.toml
@@ -40,3 +40,4 @@ GEE_SA_HTTP_COOLDOWN_SECONDS = 15  # Cooldown após 429 do download HTTP de tile
 GEE_SA_MAX_RETRIES = 2             # Máximo de rotações de SA por requisição
 GEE_SA_HEARTBEAT_INTERVAL = 30     # Intervalo de heartbeat (segundos)
 GEE_SA_ASSIGNMENT_TTL = 90         # TTL do assignment no Redis (segundos)
+GEE_SA_ACQUIRE_TIMEOUT_SECONDS = 2 # Máximo aceitável de espera no acquire antes de retornar 503

--- a/tests/unit/test_gee_pool_circuit_breaker.py
+++ b/tests/unit/test_gee_pool_circuit_breaker.py
@@ -1,0 +1,143 @@
+"""Circuit breaker em ``ServiceAccountPool.acquire()``.
+
+Antes desse fix, quando todas as SAs estavam em cooldown, o ``acquire``
+chamava ``time.sleep(60s)`` síncrono, bloqueando o worker uvicorn. O fix
+fail-fast (PoolExhaustedError → 503 com Retry-After) preserva o worker
+para atender outras requisições.
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.gee_pool import (
+    PoolExhaustedError,
+    ServiceAccountInfo,
+    ServiceAccountPool,
+)
+
+
+def _make_pool_with_two_sas() -> ServiceAccountPool:
+    """Constrói um pool com 2 SAs e Redis client mockado.
+
+    O ``__init__`` é evitado para não tocar disco/Redis. Em vez disso,
+    preenchemos os atributos necessários para ``acquire()``.
+    """
+    pool = ServiceAccountPool.__new__(ServiceAccountPool)
+    pool._sa_directory = "/tmp/fake"
+    pool._redis = MagicMock()
+    pool._accounts = {
+        "sa-a@proj": ServiceAccountInfo(name="sa-a@proj", file_path="/tmp/sa-a.json"),
+        "sa-b@proj": ServiceAccountInfo(name="sa-b@proj", file_path="/tmp/sa-b.json"),
+    }
+    return pool
+
+
+def test_acquire_raises_pool_exhausted_when_all_in_long_cooldown():
+    """Todas as SAs com cooldown > timeout → PoolExhaustedError sem sleep.
+
+    Garante que o worker não bloqueia por 60s; cliente recebe 503 e pode
+    fazer retry com Retry-After.
+    """
+    pool = _make_pool_with_two_sas()
+    now = time.time()
+    cooldown_until = now + 30.0  # 30s no futuro — muito maior que timeout default 2s
+
+    pool._redis.zrange.return_value = [
+        ("sa-a@proj", 0),
+        ("sa-b@proj", 0),
+    ]
+    pool._redis.hget.return_value = str(cooldown_until)
+
+    start = time.time()
+    with pytest.raises(PoolExhaustedError) as exc_info:
+        pool.acquire(worker_id="worker-test-1")
+    elapsed = time.time() - start
+
+    assert elapsed < 0.5, f"acquire bloqueou por {elapsed:.2f}s — circuit breaker falhou"
+    assert exc_info.value.retry_after > 25.0
+    assert exc_info.value.retry_after <= 31.0
+
+
+def test_acquire_returns_sa_when_one_is_available():
+    """SA disponível (sem cooldown) → acquire retorna sem bloqueio."""
+    pool = _make_pool_with_two_sas()
+
+    pool._redis.zrange.return_value = [
+        ("sa-a@proj", 0),
+        ("sa-b@proj", 0),
+    ]
+    # Nenhuma SA em cooldown.
+    pool._redis.hget.return_value = ""
+    pool._redis.zincrby.return_value = 1.0
+    pool._redis.set.return_value = True
+    pool._redis.hincrby.return_value = 1
+
+    # Evita carregamento real do JSON da SA (que não existe).
+    with patch.object(ServiceAccountInfo, "load_credentials", return_value=MagicMock()):
+        sa = pool.acquire(worker_id="worker-test-2")
+
+    assert sa.name in {"sa-a@proj", "sa-b@proj"}
+
+
+def test_acquire_waits_for_short_cooldown():
+    """Cooldown abaixo do timeout aceitável → acquire espera e retorna a SA.
+
+    Comportamento preserva chamadas que estavam quase pegando uma SA logo
+    após o cooldown — não devolve 503 prematuramente.
+    """
+    pool = _make_pool_with_two_sas()
+    now = time.time()
+    cooldown_until = now + 0.05  # 50ms — muito menor que timeout default de 2s
+
+    pool._redis.zrange.return_value = [
+        ("sa-a@proj", 0),
+        ("sa-b@proj", 0),
+    ]
+    pool._redis.hget.return_value = str(cooldown_until)
+    pool._redis.zincrby.return_value = 1.0
+    pool._redis.set.return_value = True
+    pool._redis.hincrby.return_value = 1
+
+    with patch.object(ServiceAccountInfo, "load_credentials", return_value=MagicMock()):
+        start = time.time()
+        sa = pool.acquire(worker_id="worker-test-3")
+        elapsed = time.time() - start
+
+    assert elapsed >= 0.04, f"esperado bloqueio breve, viu {elapsed:.3f}s"
+    assert elapsed < 1.0, f"bloqueio longo demais: {elapsed:.3f}s"
+    assert sa.name in {"sa-a@proj", "sa-b@proj"}
+
+
+def test_pool_exhausted_total_counter_increments():
+    """Métrica gee_pool_exhausted_total incrementa em cada exaustão.
+
+    Permite alerta de SLO quando o GEE upstream está saturado.
+    """
+    from prometheus_client import REGISTRY
+
+    pool = _make_pool_with_two_sas()
+    now = time.time()
+    cooldown_until = now + 30.0
+
+    pool._redis.zrange.return_value = [
+        ("sa-a@proj", 0),
+        ("sa-b@proj", 0),
+    ]
+    pool._redis.hget.return_value = str(cooldown_until)
+
+    before = REGISTRY.get_sample_value("gee_pool_exhausted_total") or 0.0
+    with pytest.raises(PoolExhaustedError):
+        pool.acquire(worker_id="worker-test-4")
+    after = REGISTRY.get_sample_value("gee_pool_exhausted_total") or 0.0
+
+    assert after == before + 1.0
+
+
+def test_pool_exhausted_error_has_retry_after_attribute():
+    """PoolExhaustedError carrega retry_after em segundos para mapeamento HTTP."""
+    err = PoolExhaustedError(retry_after=12.5)
+    assert err.retry_after == 12.5
+    assert "12.5" in str(err)

--- a/tests/unit/test_landsat_band_fallback.py
+++ b/tests/unit/test_landsat_band_fallback.py
@@ -35,6 +35,8 @@ def layers_module():
     cache_mod.aset_meta = _noop
     cache_mod.adelete_meta = _noop
     cache_mod.atile_lock = _fake_lock
+    cache_mod.PNG_TTL = 30 * 24 * 3600
+    cache_mod.PNG_TTL_HISTORICAL = 365 * 24 * 3600
     sys.modules["app.cache.cache"] = cache_mod
 
     rate_limiter_mod = type(sys)("app.middleware.rate_limiter")


### PR DESCRIPTION
## Contexto

Análise operacional identificou três problemas correlacionados em produção
que formam ciclo de degradação: P1 concentra carga em um pod → mais 429 →
cooldown global → P3 prende workers → throughput cai. P2 amplifica a
pressão sobre o GEE upstream.

## Commits (3 mudanças independentes)

### 1. `f29ff03` refactor(tiles): remove sticky cookie do Traefik e versiona stack Swarm

**Problema P1:** `app_tile_4` recebia ~17× mais carga que a mediana dos
demais pods. Investigação via Traefik API confirmou sticky cookie
`tiles_session` ativo no service `tiles-loadbalancer` em produção, no GlusterFS).

O cookie prendia cada cliente HTTP a um único pod indefinidamente.
Clientes pesados (campanhas TVI carregando muitos tiles) concentravam
todo o tráfego em um único backend.

**Mudanças:**
- Versiona o stack autoritativo de produção 
- Remove as 5 labels de sticky cookie
- Eleva `LOCAL_CACHE_SIZE` de 1000 → 10000 (compensa perda de cache
  locality; +300 MB por pod de 4 GB de limite)
- Adiciona `update_config` rolling (parallelism=2, order=start-first,
  failure_action=rollback) para deploy sem downtime
- `docs/RUNBOOK_LB_REBALANCING.md` documenta investigação, deploy e
  rollback

### 2. `1193467` feat(tiles): observabilidade granular de cache e TTL de 1 ano para Landsat histórico

**Problema P2:** Hit rate de 56.8% observado em logs do container
(`logger.info('cache HIT/MISS …')`) não distinguia origem do miss —
inviabilizava decisões sobre TTL ou capacidade de Redis.

**Mudanças:**
- `observe_cache_hit(layer, type_)` em todos os pontos de cache, com
  tipos discriminados: `png_hit`, `png_miss`, `meta_hit`, `meta_miss`,
  `catalog_hit`, `catalog_miss`
- `PNG_TTL_HISTORICAL = 365 dias` para tiles Landsat de anos passados
  (rasters imutáveis — mosaico/best image já consolidado)
- Ano corrente mantém `PNG_TTL = 30 dias` (pode receber novas passagens)

Hit rate alvo após 7 dias: ≥80% medido em
`sum(cache_hits_total{type=~\"png_hit|meta_hit\"}) / sum(cache_hits_total)`.

### 3. `1e3bb4a` feat(tiles): circuit breaker em gee_pool.acquire devolve 503 em vez de bloquear worker

**Problema P3:** Quando todas as SAs do GEE entravam em cooldown,
`acquire()` chamava `time.sleep(60s)` síncrono, prendendo o worker
uvicorn por até 1 minuto. Em rajadas isso virava queue overflow.

**Mudanças:**
- `GEE_SA_ACQUIRE_TIMEOUT_SECONDS=2` define espera máxima aceitável
- Espera > timeout → `PoolExhaustedError` → handler global mapeia para
  HTTP 503 com `Retry-After`
- Espera ≤ timeout é preservada (caso benigno: SA quase saindo de cooldown)
- Nova métrica `gee_pool_exhausted_total` (alerta de SLO quando GEE
  upstream está saturado)
- 5 testes unitários cobrem: timeout longo dispara 503 em <0.5s, timeout
  curto bloqueia e retorna SA, counter incrementa, SA disponível retorna
  sem espera, `retry_after` na exceção

## Topologia real verificada

Produção roda como Docker Swarm stack `prod_tiles` (não docker-compose
como o repositório sugeria):

| Aspecto | Valor real |
|---------|-----------|
| Arquivo | `/glusterfs/aplications/services/tiles/prod.compose.yml` |
| Réplicas | 20 (max 10/nó em vm1, vm2) |
| LB | Traefik v3.6.7 com 20 backends individuais (não VIP) |
| Strategy | `wrr` + sticky cookie `tiles_session` (esta PR remove o cookie) |

## Test plan

- [x] `pytest tests/unit -q` → **97 passed, 0 failed** (5 novos testes
  em `test_gee_pool_circuit_breaker.py`)
- [x] Validação smoke das mudanças: `LOCAL_CACHE_SIZE` env override
  funciona, default preservado, imports OK em todos os módulos
- [ ] **Deploy P1 (PR refactor — primeiro):** janela de baixo tráfego,
  seguir `docs/RUNBOOK_LB_REBALANCING.md`. Monitorar via Grafana ou
  `docker stats` por 1h. Desvio padrão de CPU entre pods deve cair para
  <0.5% em ~15 min após o rolling complete
- [ ] **Deploy P2 (feat observability):** sem ação operacional extra;
  esperar 24h e medir hit rate real via Prometheus
- [ ] **Deploy P3 (feat circuit breaker):** verificar antes se
  `tiles-client/` honra HTTP 503 + `Retry-After` (senão o usuário final
  vê erro visível). Sem retry implementado no cliente, manter
  `GEE_SA_ACQUIRE_TIMEOUT_SECONDS` alto durante observação inicial

## Riscos e mitigações

| Risco | Mitigação |
|-------|-----------|
| Sticky removido degrada hit local | `LOCAL_CACHE_SIZE=10000` (10× maior), fallback Valkey sub-ms |
| TTL longo + visparam mudado armazena viz desatualizada | Cache key já inclui `visparam` → mudança gera nova entrada |
| 503 prematuro em rajadas curtas | `GEE_SA_ACQUIRE_TIMEOUT_SECONDS=2` aceita pausas curtas; ajustável via env |
| Rolling restart durante deploy | `update_config: parallelism=2, order=start-first, failure_action=rollback` no compose |